### PR TITLE
jb/fast-defstruct

### DIFF
--- a/compiler/compiler-linking.stanza
+++ b/compiler/compiler-linking.stanza
@@ -61,7 +61,7 @@ public defstruct LinkerInput :
   auxfile:AuxFile
 
 ;The set of callbacks for performing the necessary actions.
-public defstruct LinkerEnv
+public deftype LinkerEnv
 
 ;Report to the caller that an error has occurred.
 public defmulti issue-error (e:LinkerEnv, err:LinkingError) -> False

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -490,11 +490,13 @@ defn deftype-and-multis (form:DefStructForm) -> ? :
 
     ;Type declaration
 
-    lostanza deftype Struct<targs{name}> meta-utils?{
+    deftype Struct<targs{name}> meta-utils?{
                                            <: parent?{Parent &}{} core/meta-utils/HasMetaUtils
                                          }{
                                            parent?{<: Parent}{}
-                                         }:
+                                         }
+
+    lostanza deftype LoStruct<targs{name}> <: Struct<targs{name}> :
       fields{
         setter?{ var }{} name:ref<local-type>
       }
@@ -539,7 +541,7 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
         val ensure-field-initialized-qualified-name = `qualified-name
       }{}
 
-      lostanza defmethod name<targs{?name}> (self:ref<Struct<targs{?name}>>) -> ref<type> :
+      lostanza defmethod name<targs{?name}> (self:ref<LoStruct<targs{?name}>>) -> ref<type> :
         voidable?{
           #if-not-defined(OPTIMIZE) :
             if self.name == core/uninitialized :
@@ -550,14 +552,14 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
         }
 
       voidable-with-printer-or-writer?{
-        lostanza defn raw-name<targs{?name}> (self:ref<Struct<targs{?name}>>) -> ref<type|Uninitialized> :
+        lostanza defn raw-name<targs{?name}> (self:ref<LoStruct<targs{?name}>>) -> ref<type|Uninitialized> :
           return self.name
       }{}
 
       ;Field setter.
       ;Ensure that value satisfies preconditions.
       setter?{
-        lostanza defmethod setter<targs{?name}> (self:ref<Struct<targs{?name}>>, value:ref<type>) -> ref<False> :
+        lostanza defmethod setter<targs{?name}> (self:ref<LoStruct<targs{?name}>>, value:ref<type>) -> ref<False> :
           ensure?{
             #if-not-defined(OPTIMIZE) :
               ensure(description, value)
@@ -570,7 +572,7 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
       ;Ensure that value satisfies preconditions.
       updater?{
         val description-val = description
-        lostanza defmethod updater<targs{?name}> (self:ref<Struct<targs{?name}>>, local-name:ref<type>) -> ref<Struct<targs{name}>> :
+        lostanza defmethod updater<targs{?name}> (self:ref<LoStruct<targs{?name}>>, local-name:ref<type>) -> ref<LoStruct<targs{name}>> :
           ensure?{
             #if-not-defined(OPTIMIZE) :
               ensure(description-val, local-name)
@@ -657,8 +659,8 @@ defn printer-and-writer (form:DefStructForm) -> ? :
 defn main-constructor (form:DefStructForm,
                        main-constructor:Token|Symbol) -> ? :
   val template = `(
-    lostanza defn MainConstructor<targs{name}> (fields{name:ref<local-type>}) -> ref<Struct<targs{name}>> :
-      return new Struct<targs{name}>{ fields{name} }
+    lostanza defn MainConstructor<targs{name}> (fields{name:ref<local-type>}) -> ref<LoStruct<targs{name}>> :
+      return new LoStruct<targs{name}>{ fields{name} }
           
     ;Getters, setters, and updaters for each field.
     getters-setters-updaters
@@ -691,10 +693,10 @@ defn simple-constructor (form:DefStructForm,
 
   val template = `(
 
-    lostanza defn LoConstructor<targs{name}> (fields{name:ref<local-type>}) -> ref<Struct<targs{name}>> :
-      return new Struct<targs{name}>{ fields{name} }
+    lostanza defn LoConstructor<targs{name}> (fields{name:ref<local-type>}) -> ref<LoStruct<targs{name}>> :
+      return new LoStruct<targs{name}>{ fields{name} }
           
-    defn Constructor<targs{name}> (fields{init?{}{local-name:type}}) -> Struct<targs{name}> :
+    defn Constructor<targs{name}> (fields{init?{}{local-name:type}}) -> LoStruct<targs{name}> :
       ;Initialize 'init' fields.
       fields{
         init?{
@@ -1052,8 +1054,11 @@ public defn compile (form:DefStructForm) -> ? :
     hashable-equalable-methods
     constructors)
 
+  val lo-name = gensym(form.name)
+
   val res = fill-template(template, [
     `Struct => deep(form.name)
+    `LoStruct => deep(lo-name)
     `targs => deep(repeated([`name => form.targs]))
     `fields => deep(/bindings(form, form.fields, form.name))
     `x => deep(gensym(`x))

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -39,6 +39,7 @@ public defstruct DefStructForm :
   equalable?: True|False
   hashable?: True|False
   meta-utils?: True|False
+  lo-type:Token|Symbol|False|True
 
 ;Represents a field declaration in a DefStruct.
 ;- name: The name of the field.
@@ -80,6 +81,7 @@ public defstruct ForwardToWriter
 ;Listing of all supported struct options.
 public deftype StructOption
 public defstruct Constructor <: StructOption: (value:Token|True|False|Symbol)
+public defstruct LoType <: StructOption: (value:Token|False|True|Symbol)
 public defstruct KeywordConstructor <: StructOption: (value:Token|True|False|Symbol)
 public defstruct GenPrinter <: StructOption: (value:True|False)
 public defstruct GenWriter <: StructOption: (value:True|False)
@@ -110,6 +112,7 @@ defn name (o:FieldOption) -> Symbol :
 defn name (o:StructOption) -> Symbol :
   match(o) :
     (o:Constructor) : `constructor
+    (o:LoType) : `lo-type
     (o:KeywordConstructor) : `keyword-constructor
     (o:GenPrinter) : `printer
     (o:GenWriter) : `writer
@@ -180,6 +183,7 @@ public defn DefStructForm (info:FileInfo|False,
 
   ;Process the options.
   var constructor = true
+  var lo-type = false
   var keyword-constructor = false
   var printer? = None()
   var writer? = false
@@ -189,6 +193,7 @@ public defn DefStructForm (info:FileInfo|False,
   for o in options :
     match(o) :
       (o:Constructor) : constructor = o.value
+      (o:LoType) : lo-type = o.value
       (o:KeywordConstructor) : keyword-constructor = o.value
       (o:GenPrinter) : printer? = One(o.value)
       (o:GenWriter) : writer? = o.value
@@ -228,7 +233,8 @@ public defn DefStructForm (info:FileInfo|False,
                 writer?,
                 equalable?,
                 hashable?,
-                meta-utils?)
+                meta-utils?,
+                lo-type)
 
 ;============================================================
 ;====================== Parsing =============================
@@ -267,6 +273,7 @@ defsyntax defstruct-syntax :
   ;Syntax of each option.
   defproduction struct-option!:StructOption
   defrule struct-option! = (constructor ?name:#bool-id-setting) : Constructor(name)
+  defrule struct-option! = (lo-type ?name:#bool-id-setting) : LoType(name)
   defrule struct-option! = (keyword-constructor ?name:#bool-id-setting) : KeywordConstructor(name)
   defrule struct-option! = (printer ?v:#bool-setting) : GenPrinter(v)
   defrule struct-option! = (writer ?v:#bool-setting) : GenWriter(v)
@@ -1056,7 +1063,10 @@ public defn compile (form:DefStructForm) -> ? :
     hashable-equalable-methods
     constructors)
 
-  val lo-name = gensym(form.name)
+  val lo-name =
+    match(form.lo-type) :
+      (name:Symbol|Token) : name
+      (name) : symbol-join $ ["Lo" form.name]
 
   val res = fill-template(template, [
     `Struct => deep(form.name)

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -331,6 +331,8 @@ defn CSE (info:FileInfo|False, msg) :
 defn bindings (fields:List<StructField>,
                struct-name:Symbol|Token) -> Nested :
 
+  val all-field-names = to-tuple(seq({_.name}, fields))
+
   ;Generate the bindings for the given field at index 'index'.
   defn bindings (field:StructField, index:Int) -> Tuple<KeyValue> :
 
@@ -385,6 +387,9 @@ defn bindings (fields:List<StructField>,
       (name:True) : sub-token-item?(field.updater, symbol-join(["sub-", field.name]))
       (name:False) : false
 
+    val prev-names = repeated([`name => all-field-names[0 to index]])
+    val post-names = repeated([`name => all-field-names[(index + 1) to false]])
+
     [`name => field.name
      `type => field.type
      `first? => choice(index == 0)
@@ -408,7 +413,9 @@ defn bindings (fields:List<StructField>,
      `init-value => field.init.value?
      `default? => choice(not field.default.empty?)
      `default-value => field.default.value?
-     `initialized? => initialized?]
+     `initialized? => initialized?
+     `prev-names => prev-names
+     `post-names => post-names]
 
   ;Generate the bindings for each field.
   nested $ to-tuple $
@@ -557,7 +564,7 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
             #if-not-defined(OPTIMIZE) :
               ensure(description, local-name)
           }{}
-          MainConstructor<targs{name}>(fields{local-name})
+          MainConstructor<targs{name}>(prev-names{name(self)} local-name post-names{name(self)})
       }{}
 
     }
@@ -687,7 +694,7 @@ defn simple-constructor (form:DefStructForm,
           }
         }{}
       }
-      LoConstructor(
+      LoConstructor<targs{name}>(
         fields{
           init?{
             voidable?{

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -399,7 +399,7 @@ defn bindings (fields:List<StructField>,
      `updater => updater-name
      `ensure? => choice(not field.ensure.empty?)
      `ensure => field.ensure.value?
-     `ensure-field-initialized => gensym(symbol-join(["ensure-field-" struct-name '-' field.name "-initialized" ]))
+     ; `ensure-field-initialized => gensym(symbol-join(["ensure-field-" struct-name '-' field.name "-initialized" ]))
      `local-name => local-name
      `local-type => local-type
      `arg-name => arg-name
@@ -524,15 +524,15 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
 
       ;Field getter.
       ;If voidable, then checks that the value is set.
-      voidable?{
-        defn ensure-field-initialized (x:type) :
-          ensure-initialized(x, `qualified-name)
-      }{}
+      ; voidable?{
+      ;   defn ensure-field-initialized (x:type) :
+      ;     ensure-initialized(x, `qualified-name)
+      ; }{}
 
       lostanza defmethod name<targs{?name}> (self:ref<Struct<targs{?name}>>) -> ref<type> :
         voidable?{
-          ensure-field-initialized(self.name)
-          return self.name as type
+          ; ensure-field-initialized(self.name)
+          return self.name as ref<type>
         }{
           return self.name
         }
@@ -552,12 +552,12 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
       ;Field updater.
       ;Ensure that value satisfies preconditions.
       updater?{
-        defmethod updater<targs<?name>> (self:Struct<targs<?name>>, local-name:type) :
+        defmethod updater<targs{?name}> (self:Struct<targs{?name}>, local-name:type) :
           ensure?{
             #if-not-defined(OPTIMIZE) :
-              ensure(description, name(self))
+              ensure(description, local-name)
           }{}
-          MainConstructor<targs{name}>(fields{name(self)})
+          MainConstructor<targs{name}>(fields{local-name})
       }{}
 
     }

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -399,6 +399,7 @@ defn bindings (fields:List<StructField>,
      `updater => updater-name
      `ensure? => choice(not field.ensure.empty?)
      `ensure => field.ensure.value?
+     `ensure-field-initialized => gensym(symbol-join(["ensure-field-" struct-name '-' field.name "-initialized" ]))
      `local-name => local-name
      `local-type => local-type
      `arg-name => arg-name
@@ -477,11 +478,16 @@ defn deftype-and-multis (form:DefStructForm) -> ? :
   val template = `(
 
     ;Type declaration
-    deftype Struct<targs{name}> meta-utils?{
-                                  <: parent?{Parent &}{} core/meta-utils/HasMetaUtils
-                                }{
-                                  parent?{<: Parent}{}
-                                }
+
+    lostanza deftype Struct<targs{name}> meta-utils?{
+                                           <: parent?{Parent &}{} core/meta-utils/HasMetaUtils
+                                         }{
+                                           parent?{<: Parent}{}
+                                         }:
+      fields{
+        setter?{ var }{} name:ref<type>
+      }
+
 
     ;Field multis
     fields{
@@ -518,37 +524,40 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
 
       ;Field getter.
       ;If voidable, then checks that the value is set.
-      defmethod name (this) :
-        voidable?{
-          #if-not-defined(OPTIMIZE) :
-            if local-name is Uninitialized :
-              fatal("Field %_ has not been initialized." % [`qualified-name])
-          local-name as type
-        }{
-          local-name
-        }
+      voidable?{
+        defn ensure-field-initialized (x:type) :
+          ensure-initialized(x, `qualified-name)
+      }{}
 
+      lostanza defmethod name<targs{?name}> (self:ref<Struct<targs{?name}>>) -> ref<type> :
+        voidable?{
+          ensure-field-initialized(self.name)
+          return self.name as type
+        }{
+          return self.name
+        }
 
       ;Field setter.
       ;Ensure that value satisfies preconditions.
       setter?{
-        defmethod setter (this, value:type) :
+        lostanza defmethod setter (self:ref<Struct>, value:ref<type>) -> ref<False> :
           ensure?{
             #if-not-defined(OPTIMIZE) :
               ensure(description, value)
           }{}
-          local-name = value
+          self.name = value
+          return false
       }{}
 
       ;Field updater.
       ;Ensure that value satisfies preconditions.
       updater?{
-        defmethod updater (this, local-name:type) :
+        defmethod updater<targs<?name>> (self:Struct<targs<?name>>, local-name:type) :
           ensure?{
             #if-not-defined(OPTIMIZE) :
-              ensure(description, local-name)
+              ensure(description, name(self))
           }{}
-          MainConstructor<targs{name}>(fields{local-name})
+          MainConstructor<targs{name}>(fields{name(self)})
       }{}
 
     }
@@ -567,14 +576,14 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
 defn printer-and-writer (form:DefStructForm) -> ? :
   val template = `(
     printer?{
-      defmethod print (o:OutputStream, this) :
+      defmethod print (o:OutputStream, self:Struct) :
         val print-items = [
           fields{
             voidable?{
-              if local-name is Uninitialized : "%~ = void" % [`name]
-              else : "%~ = %~" % [`name, local-name]
+              if name(self) is Uninitialized : "%~ = void" % [`name]
+              else : "%~ = %~" % [`name, name(self)]
             }{
-              "%~ = %~" % [`name, local-name]
+              "%~ = %~" % [`name, name(self)]
             }
           }
         ]
@@ -582,20 +591,20 @@ defn printer-and-writer (form:DefStructForm) -> ? :
     }{}
 
     forward-to-writer?{
-      defmethod print (o:OutputStream, this) :
-        write(o, this)
+      defmethod print (o:OutputStream, self:Struct) :
+        write(o, self)
     }{}
     
     writer?{
-      defmethod write (o:OutputStream, this) :
+      defmethod write (o:OutputStream, self:Struct) :
         val write-items = Vector<?>()
         fields{
           init?{}{
             voidable?{
-              if local-name is-not Uninitialized :
-                collections/add(write-items, "%~" % [local-name])
+              if name(self) is-not Uninitialized :
+                collections/add(write-items, "%~" % [name(self)])
             }{
-              collections/add(write-items, "%~" % [local-name])
+              collections/add(write-items, "%~" % [name(self)])
             }
           }
         }
@@ -630,21 +639,14 @@ defn printer-and-writer (form:DefStructForm) -> ? :
 defn main-constructor (form:DefStructForm,
                        main-constructor:Token|Symbol) -> ? :
   val template = `(
-    defn MainConstructor<targs{name}> (fields{name:local-type}) :
+    lostanza defn MainConstructor<targs{name}> (fields{name:ref<type>}) -> ref<Struct<targs{name}>> :
+      return new Struct<targs{name}>{ fields{name} }
+          
+    ;Getters, setters, and updaters for each field.
+    getters-setters-updaters
 
-      ;Define mutable local variables.
-      fields{setter?{
-        var local-name:local-type = name
-      }{}}
-
-      ;Create struct.
-      new Struct<targs{name}> :
-
-        ;Getters, setters, and updaters for each field.
-        getters-setters-updaters
-
-        ;Printer and writer
-        printer-and-writer
+    ;Printer and writer
+    printer-and-writer
   )
 
   splice $ substitute(template, [
@@ -666,23 +668,15 @@ defn main-constructor (form:DefStructForm,
 ;  - No ensures.
 ;  - No inits.
 defn simple-constructor (form:DefStructForm,
+                         lo-constructor:Symbol,
                          constructor:Symbol|Token) -> ? :
 
   val template = `(
 
-    defn Constructor<targs{name}> (fields{init?{}{name:type}}) :
-
-      ;Initialize 'init' fields.
-      fields{
-        init?{
-          voidable?{
-            var name:type
-          }{
-            val name:type = init-value
-          }
-        }{}
-      }
-
+    lostanza defn LoConstructor<targs{name}> (fields{name:ref<type>}) -> ref<Struct<targs{name}>> :
+      return new Struct<targs{name}>{ fields{name} }
+          
+    defn Constructor<targs{name}> (fields{init?{}{name:type}}) -> Struct<targs{name}> :
       ;Check preconditions.
       fields{
         ensure?{
@@ -693,29 +687,28 @@ defn simple-constructor (form:DefStructForm,
           }
         }{}
       }
-
-      ;Define mutable local variables.
-      fields{
-        setter?{
-          voidable?{
-            var local-name:local-type = uninitialized
+      LoConstructor(
+        fields{
+          init?{
+            voidable?{
+              uinitialized
+            }{
+              init-value
+            }
           }{
-            var local-name:type = name
+            name
           }
-        }{}
-      }
-
-      ;Create struct.
-      new Struct<targs{name}> :
-
-        ;Getters, setters, and updaters for each field.
-        getters-setters-updaters
-
-        ;Printer and writer
-        printer-and-writer
+        }
+      )
+          
+    ;Getters etc
+    getters-setters-updaters
+    ;Printer and writer
+    printer-and-writer
   )
 
   splice $ substitute(template, [
+    `LoConstructor => lo-constructor
     `Constructor => constructor
     `getters-setters-updaters => getters-setters-updaters(constructor)
     `printer-and-writer => printer-and-writer(form)])
@@ -924,6 +917,8 @@ defn all-constructors (form:DefStructForm) -> ? :
     (c:True) : form.name
     (c:False) : false
 
+  val lo-constructor-name = gensym(form.name)
+
   ;Generate the name of the main constructor.
   val main-constructor-name = gensym(form.name)
 
@@ -936,7 +931,7 @@ defn all-constructors (form:DefStructForm) -> ? :
   ;Compute the simple constructor.
   val simple-constructor =
     if form.use-simple-constructor? :
-      One(simple-constructor(form, constructor-name as Token|Symbol))
+      One(simple-constructor(form, lo-constructor-name, constructor-name as Token|Symbol))
     else :
       None()
 
@@ -1035,6 +1030,7 @@ public defn compile (form:DefStructForm) -> ? :
     `x => deep(gensym(`x))
     `Uninitialized => deep(`core/Uninitialized)
     `uninitialized => deep(`core/uninitialized)
+    `ensure-initalized => deep(`core/ensure-initialized)
     `deftype-and-multis => deftype-and-multis(form)
     `meta-utils-methods => meta-utils-methods(form)
     `hashable-equalable-methods => hashable-equalable-methods(form)

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(dot-operator)
-defpackage stz/defclass-macro :
+defpackage stz/defstruct-macro :
   import core
   import collections
   import macro-utils
@@ -557,7 +557,7 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
       ;Field setter.
       ;Ensure that value satisfies preconditions.
       setter?{
-        lostanza defmethod setter (self:ref<Struct>, value:ref<type>) -> ref<False> :
+        lostanza defmethod setter<targs{?name}> (self:ref<Struct<targs{?name}>>, value:ref<type>) -> ref<False> :
           ensure?{
             #if-not-defined(OPTIMIZE) :
               ensure(description, value)

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(dot-operator)
-defpackage stz/defstruct-macro :
+defpackage stz/defclass-macro :
   import core
   import collections
   import macro-utils
@@ -722,7 +722,7 @@ defn simple-constructor (form:DefStructForm,
             voidable?{
               uninitialized
             }{
-              init-value
+              name
             }
           }{
             name
@@ -1065,6 +1065,8 @@ public defn compile (form:DefStructForm) -> ? :
     `hashable-equalable-methods => hashable-equalable-methods(form)
     `constructors => all-constructors(form)])
 
+  ; println(res)
+  
   res
 
 ;============================================================

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -434,14 +434,14 @@ defn bindings (form:DefStructForm,
 defn meta-utils-methods (form:DefStructForm) -> ? :
   val template = `(
     meta-utils?{
-      defmethod core/meta-utils/field-values (x:Struct) :
+      defmethod core/meta-utils/field-values (x:LoStruct) :
         [fields{name(x)}]
-      defmethod core/meta-utils/field-names (x:Struct) :
+      defmethod core/meta-utils/field-names (x:LoStruct) :
         [fields{`name}]
-      defmethod core/meta-utils/field-accessors (x:Struct) :
-        val accessors = [fields{name upcast-as (Struct -> ?)}]
+      defmethod core/meta-utils/field-accessors (x:LoStruct) :
+        val accessors = [fields{name upcast-as (LoStruct -> ?)}]
         accessors as Tuple<(core/meta-utils/HasMetaUtils -> ?)>
-      defmethod core/meta-utils/field-entries (x:Struct) :
+      defmethod core/meta-utils/field-entries (x:LoStruct) :
         [fields{`name => name(x)}]
     }{}
   )
@@ -456,7 +456,7 @@ defn meta-utils-methods (form:DefStructForm) -> ? :
 defn hashable-equalable-methods (form:DefStructForm) -> ? :
   val template = `(
     equalable?{
-      defmethod equal? (lhs:Struct, rhs:Struct) :
+      defmethod equal? (lhs:LoStruct, rhs:LoStruct) :
         has-fields?{
           fields{first?{}{and} equal?(name(lhs), name(rhs))}
         }{
@@ -465,7 +465,7 @@ defn hashable-equalable-methods (form:DefStructForm) -> ? :
     }{}
 
     hashable?{
-      defmethod hash (x:Struct) :
+      defmethod hash (x:LoStruct) :
         hash([Struct-name fields{name(x)}])
     }{}
   )
@@ -596,7 +596,7 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
 defn printer-and-writer (form:DefStructForm) -> ? :
   val template = `(
     printer?{
-      defmethod print (o:OutputStream, self:Struct) :
+      defmethod print (o:OutputStream, self:LoStruct) :
         val print-items = [
           fields{
             voidable?{
@@ -611,12 +611,12 @@ defn printer-and-writer (form:DefStructForm) -> ? :
     }{}
 
     forward-to-writer?{
-      defmethod print (o:OutputStream, self:Struct) :
+      defmethod print (o:OutputStream, self:LoStruct) :
         write(o, self)
     }{}
     
     writer?{
-      defmethod write (o:OutputStream, self:Struct) :
+      defmethod write (o:OutputStream, self:LoStruct) :
         val write-items = Vector<?>()
         fields{
           init?{}{
@@ -700,7 +700,9 @@ defn simple-constructor (form:DefStructForm,
       ;Initialize 'init' fields.
       fields{
         init?{
-          val name:type = init-value
+          voidable?{}{
+            val name:type = init-value
+          }
         }{
           setter?{
             val name:type = local-name

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -328,7 +328,8 @@ defn CSE (info:FileInfo|False, msg) :
 ;============================================================
 
 ;Generate the bindings for the given fields.
-defn bindings (fields:List<StructField>,
+defn bindings (form:DefStructForm,
+               fields:List<StructField>,
                struct-name:Symbol|Token) -> Nested :
 
   val all-field-names = to-tuple(seq({_.name}, fields))
@@ -391,10 +392,12 @@ defn bindings (fields:List<StructField>,
     val post-names = repeated([`name => all-field-names[(index + 1) to false]])
 
     [`name => field.name
+     `raw-name => gensym(symbol-join(["raw-" field.name]))
      `type => field.type
      `first? => choice(index == 0)
      `doc-string => field.doc-string.value?
      `doc-string? => choice(not field.doc-string.empty?)
+     `description-val => gensym(symbol-join(["ensure-field-" struct-name '-' field.name "-initialized" ]))
      `description => to-string("field %_/%_" % [struct-name, field.name])
      `qualified-name => symbol-join([struct-name '/' field.name])
      `method? => choice(field.as-method?)
@@ -404,16 +407,17 @@ defn bindings (fields:List<StructField>,
      `updater => updater-name
      `ensure? => choice(not field.ensure.empty?)
      `ensure => field.ensure.value?
-     ; `ensure-field-initialized => gensym(symbol-join(["ensure-field-" struct-name '-' field.name "-initialized" ]))
      `local-name => local-name
      `local-type => local-type
      `arg-name => arg-name
      `voidable? => choice(voidable?)
      `init? => choice(not field.init.empty?)
      `init-value => field.init.value?
+     `ensure-field-initialized-qualified-name => gensym(symbol-join(["ensure-field-" struct-name '-' field.name "-initialized-name" ]))
      `default? => choice(not field.default.empty?)
      `default-value => field.default.value?
      `initialized? => initialized?
+     `voidable-with-printer-or-writer? => choice(voidable? and (form.printer? is True or form.writer? is True))
      `prev-names => prev-names
      `post-names => post-names]
 
@@ -531,18 +535,24 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
 
       ;Field getter.
       ;If voidable, then checks that the value is set.
-      ; voidable?{
-      ;   defn ensure-field-initialized (x:type) :
-      ;     ensure-initialized(x, `qualified-name)
-      ; }{}
+      voidable?{
+        val ensure-field-initialized-qualified-name = `qualified-name
+      }{}
 
       lostanza defmethod name<targs{?name}> (self:ref<Struct<targs{?name}>>) -> ref<type> :
         voidable?{
-          ; ensure-field-initialized(self.name)
+          #if-not-defined(OPTIMIZE) :
+            if self.name == core/uninitialized :
+              uninitialized-field-error(ensure-field-initialized-qualified-name)
           return self.name as ref<type>
         }{
           return self.name
         }
+
+      voidable-with-printer-or-writer?{
+        lostanza defn raw-name<targs{?name}> (self:ref<Struct<targs{?name}>>) -> ref<type|Uninitialized> :
+          return self.name
+      }{}
 
       ;Field setter.
       ;Ensure that value satisfies preconditions.
@@ -559,12 +569,13 @@ defn getters-setters-updaters (main-constructor:Token|Symbol) -> ? :
       ;Field updater.
       ;Ensure that value satisfies preconditions.
       updater?{
-        defmethod updater<targs{?name}> (self:Struct<targs{?name}>, local-name:type) :
+        val description-val = description
+        lostanza defmethod updater<targs{?name}> (self:ref<Struct<targs{?name}>>, local-name:ref<type>) -> ref<Struct<targs{name}>> :
           ensure?{
             #if-not-defined(OPTIMIZE) :
-              ensure(description, local-name)
+              ensure(description-val, local-name)
           }{}
-          MainConstructor<targs{name}>(prev-names{name(self)} local-name post-names{name(self)})
+          return MainConstructor<targs{name}>(prev-names{self.name} local-name post-names{self.name})
       }{}
 
     }
@@ -587,7 +598,7 @@ defn printer-and-writer (form:DefStructForm) -> ? :
         val print-items = [
           fields{
             voidable?{
-              if name(self) is Uninitialized : "%~ = void" % [`name]
+              if raw-name(self) is Uninitialized : "%~ = void" % [`name]
               else : "%~ = %~" % [`name, name(self)]
             }{
               "%~ = %~" % [`name, name(self)]
@@ -608,7 +619,7 @@ defn printer-and-writer (form:DefStructForm) -> ? :
         fields{
           init?{}{
             voidable?{
-              if name(self) is-not Uninitialized :
+              if raw-name(self) is-not Uninitialized :
                 collections/add(write-items, "%~" % [name(self)])
             }{
               collections/add(write-items, "%~" % [name(self)])
@@ -683,7 +694,18 @@ defn simple-constructor (form:DefStructForm,
     lostanza defn LoConstructor<targs{name}> (fields{name:ref<local-type>}) -> ref<Struct<targs{name}>> :
       return new Struct<targs{name}>{ fields{name} }
           
-    defn Constructor<targs{name}> (fields{init?{}{name:type}}) -> Struct<targs{name}> :
+    defn Constructor<targs{name}> (fields{init?{}{local-name:type}}) -> Struct<targs{name}> :
+      ;Initialize 'init' fields.
+      fields{
+        init?{
+          val name:type = init-value
+        }{
+          setter?{
+            val name:type = local-name
+          }{}
+        }
+      }
+
       ;Check preconditions.
       fields{
         ensure?{
@@ -698,7 +720,7 @@ defn simple-constructor (form:DefStructForm,
         fields{
           init?{
             voidable?{
-              uinitialized
+              uninitialized
             }{
               init-value
             }
@@ -954,7 +976,7 @@ defn all-constructors (form:DefStructForm) -> ? :
   val positional-constructor =
     match(constructor-name:Token|Symbol) :
       if positional-vs-keyword-ambiguity?(form) :
-        val new-fields = bindings(form.force-required-field, form.name)
+        val new-fields = bindings(form, form.force-required-field, form.name)
         One $ positional-constructor(constructor-name, main-constructor-name, new-fields)
       else :
         One $ positional-constructor(constructor-name, main-constructor-name)
@@ -1033,17 +1055,15 @@ public defn compile (form:DefStructForm) -> ? :
   val res = fill-template(template, [
     `Struct => deep(form.name)
     `targs => deep(repeated([`name => form.targs]))
-    `fields => deep(/bindings(form.fields, form.name))
+    `fields => deep(/bindings(form, form.fields, form.name))
     `x => deep(gensym(`x))
     `Uninitialized => deep(`core/Uninitialized)
     `uninitialized => deep(`core/uninitialized)
-    `ensure-initalized => deep(`core/ensure-initialized)
+    `uninitialized-field-error => deep(`core/uninitialized-field-error)
     `deftype-and-multis => deftype-and-multis(form)
     `meta-utils-methods => meta-utils-methods(form)
     `hashable-equalable-methods => hashable-equalable-methods(form)
     `constructors => all-constructors(form)])
-
-  println(res)
 
   res
 

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -492,7 +492,7 @@ defn deftype-and-multis (form:DefStructForm) -> ? :
                                            parent?{<: Parent}{}
                                          }:
       fields{
-        setter?{ var }{} name:ref<type>
+        setter?{ var }{} name:ref<local-type>
       }
 
 
@@ -646,7 +646,7 @@ defn printer-and-writer (form:DefStructForm) -> ? :
 defn main-constructor (form:DefStructForm,
                        main-constructor:Token|Symbol) -> ? :
   val template = `(
-    lostanza defn MainConstructor<targs{name}> (fields{name:ref<type>}) -> ref<Struct<targs{name}>> :
+    lostanza defn MainConstructor<targs{name}> (fields{name:ref<local-type>}) -> ref<Struct<targs{name}>> :
       return new Struct<targs{name}>{ fields{name} }
           
     ;Getters, setters, and updaters for each field.
@@ -680,7 +680,7 @@ defn simple-constructor (form:DefStructForm,
 
   val template = `(
 
-    lostanza defn LoConstructor<targs{name}> (fields{name:ref<type>}) -> ref<Struct<targs{name}>> :
+    lostanza defn LoConstructor<targs{name}> (fields{name:ref<local-type>}) -> ref<Struct<targs{name}>> :
       return new Struct<targs{name}>{ fields{name} }
           
     defn Constructor<targs{name}> (fields{init?{}{name:type}}) -> Struct<targs{name}> :
@@ -1030,7 +1030,7 @@ public defn compile (form:DefStructForm) -> ? :
     hashable-equalable-methods
     constructors)
 
-  fill-template(template, [
+  val res = fill-template(template, [
     `Struct => deep(form.name)
     `targs => deep(repeated([`name => form.targs]))
     `fields => deep(/bindings(form.fields, form.name))
@@ -1042,6 +1042,10 @@ public defn compile (form:DefStructForm) -> ? :
     `meta-utils-methods => meta-utils-methods(form)
     `hashable-equalable-methods => hashable-equalable-methods(form)
     `constructors => all-constructors(form)])
+
+  println(res)
+
+  res
 
 ;============================================================
 ;================== Small Utilities =========================

--- a/compiler/defstruct-macro.stanza
+++ b/compiler/defstruct-macro.stanza
@@ -496,7 +496,7 @@ defn deftype-and-multis (form:DefStructForm) -> ? :
                                            parent?{<: Parent}{}
                                          }
 
-    lostanza deftype LoStruct<targs{name}> <: Struct<targs{name}> :
+    private lostanza deftype LoStruct<targs{name}> <: Struct<targs{name}> :
       fields{
         setter?{ var }{} name:ref<local-type>
       }
@@ -693,7 +693,7 @@ defn simple-constructor (form:DefStructForm,
 
   val template = `(
 
-    lostanza defn LoConstructor<targs{name}> (fields{name:ref<local-type>}) -> ref<LoStruct<targs{name}>> :
+    private lostanza defn LoConstructor<targs{name}> (fields{name:ref<local-type>}) -> ref<LoStruct<targs{name}>> :
       return new LoStruct<targs{name}>{ fields{name} }
           
     defn Constructor<targs{name}> (fields{init?{}{local-name:type}}) -> LoStruct<targs{name}> :

--- a/compiler/resolver.stanza
+++ b/compiler/resolver.stanza
@@ -1064,7 +1064,7 @@ defn SymbolTable (package-name:Symbol, base:NameMap|Tuple<Export>) :
 
   ; Helper for adding VEntries to collection only if they have not
   ;   already been added
-  defn add-unique<?E> (e:?E&Equalable, entries:List<E&Equalable>) -> List<E> :
+  defn add-unique<?E> (e:?E&Equalable, entries:List<?E&Equalable>) -> List<E> :
     if contains?(entries, e) : entries
     else : cons(e, entries)
 

--- a/compiler/vm-ir.stanza
+++ b/compiler/vm-ir.stanza
@@ -38,40 +38,20 @@ public val NUM-BUILTIN-FNS = 4
 ;================== Design of Instructions ==================
 ;============================================================
 
-public deftype VMPackage
-public defmulti packageio (p:VMPackage) -> PackageIO
-public defmulti init (p:VMPackage) -> Int|False
-public defmulti globals (p:VMPackage) -> Tuple<VMGlobal>
-public defmulti sub-globals (p:VMPackage, g:Tuple<VMGlobal>) -> VMPackage
-public defmulti datas (p:VMPackage) -> Tuple<VMData>
-public defmulti sub-datas (p:VMPackage, g:Tuple<VMData>) -> VMPackage
-public defmulti consts (p:VMPackage) -> Tuple<VMConst>
-public defmulti classes (p:VMPackage) -> Tuple<VMClass>
-public defmulti funcs (p:VMPackage) -> Tuple<VMDefn>
-public defmulti sub-funcs (p:VMPackage, g:Tuple<VMDefn>) -> VMPackage
-public defmulti methods (p:VMPackage) -> Tuple<VMMethod>
-public defmulti externs (p:VMPackage) -> Tuple<VMExtern>
-public defmulti extern-defns (p:VMPackage) -> Tuple<VMExternDefn>
-public defmulti debug-name-table (p:VMPackage) -> VMDebugNameTable
-public defmulti debug-table (p:VMPackage) -> VMDebugInfoTable
-public defmulti safepoint-table (p:VMPackage) -> VMSafepointTable
-
-public defstruct #VMPackage <: VMPackage :
-  packageio: PackageIO with: (as-method => true)
-  init: Int|False with: (as-method => true)
-  globals: Tuple<VMGlobal> with: (updater => sub-globals, as-method => true)
-  datas: Tuple<VMData> with: (updater => sub-datas, as-method => true)
-  consts: Tuple<VMConst> with: (as-method => true)
-  classes: Tuple<VMClass> with: (as-method => true)
-  funcs: Tuple<VMDefn> with: (updater => sub-funcs, as-method => true)
-  methods: Tuple<VMMethod> with: (as-method => true)
-  externs: Tuple<VMExtern> with: (as-method => true)
-  extern-defns: Tuple<VMExternDefn> with: (as-method => true)
-  debug-name-table: VMDebugNameTable with: (as-method => true)
-  debug-table: VMDebugInfoTable with: (as-method => true)
-  safepoint-table: VMSafepointTable with: (as-method => true)
-with:
-  constructor => VMPackage
+public defstruct VMPackage :
+  packageio: PackageIO
+  init: Int|False
+  globals: Tuple<VMGlobal> with: (updater => sub-globals)
+  datas: Tuple<VMData> with: (updater => sub-datas)
+  consts: Tuple<VMConst>
+  classes: Tuple<VMClass>
+  funcs: Tuple<VMDefn> with: (updater => sub-funcs)
+  methods: Tuple<VMMethod>
+  externs: Tuple<VMExtern>
+  extern-defns: Tuple<VMExternDefn>
+  debug-name-table: VMDebugNameTable
+  debug-table: VMDebugInfoTable
+  safepoint-table: VMSafepointTable
 
 ;A value that can be accessed directly within an instruction.
 public deftype VMImm
@@ -154,20 +134,10 @@ public defstruct VMDef :
   type: VMType
   local: Int with: (default => 0, updater => sub-local)
 
-public deftype VMDefn
-public defmulti id (d:VMDefn) -> Int
-public defmulti sub-id (d:VMDefn, id:Int) -> VMDefn
-public defmulti dependencies (d:VMDefn) -> Tuple<Int>
-public defmulti sub-dependencies (d:VMDefn, dependencies:Tuple<Int>) -> VMDefn
-public defmulti func (d:VMDefn) -> VMFunction
-public defmulti sub-func (d:VMDefn, func:VMFunction) -> VMDefn
-
-public defstruct #VMDefn <: VMDefn :
-  id: Int with: (updater => sub-id, as-method => true)
-  dependencies: Tuple<Int> with: (default => [], updater => sub-dependencies, as-method => true)
-  func: VMFunction with: (updater => sub-func, as-method => true)
-with:
-  constructor => VMDefn
+public defstruct VMDefn :
+  id: Int with: (updater => sub-id)
+  dependencies: Tuple<Int> with: (default => [], updater => sub-dependencies)
+  func: VMFunction with: (updater => sub-func)
 
 ;Indicates that the function 'fid' is called externally.
 ;- lbl: If given, the static label of this function. When statically-compiled,

--- a/compiler/vm-ir.stanza
+++ b/compiler/vm-ir.stanza
@@ -38,20 +38,40 @@ public val NUM-BUILTIN-FNS = 4
 ;================== Design of Instructions ==================
 ;============================================================
 
-public defstruct VMPackage :
-  packageio: PackageIO
-  init: Int|False
-  globals: Tuple<VMGlobal> with: (updater => sub-globals)
-  datas: Tuple<VMData> with: (updater => sub-datas)
-  consts: Tuple<VMConst>
-  classes: Tuple<VMClass>
-  funcs: Tuple<VMDefn> with: (updater => sub-funcs)
-  methods: Tuple<VMMethod>
-  externs: Tuple<VMExtern>
-  extern-defns: Tuple<VMExternDefn>
-  debug-name-table: VMDebugNameTable
-  debug-table: VMDebugInfoTable
-  safepoint-table: VMSafepointTable
+public deftype VMPackage
+public defmulti packageio (p:VMPackage) -> PackageIO
+public defmulti init (p:VMPackage) -> Int|False
+public defmulti globals (p:VMPackage) -> Tuple<VMGlobal>
+public defmulti sub-globals (p:VMPackage, g:Tuple<VMGlobal>) -> VMPackage
+public defmulti datas (p:VMPackage) -> Tuple<VMData>
+public defmulti sub-datas (p:VMPackage, g:Tuple<VMData>) -> VMPackage
+public defmulti consts (p:VMPackage) -> Tuple<VMConst>
+public defmulti classes (p:VMPackage) -> Tuple<VMClass>
+public defmulti funcs (p:VMPackage) -> Tuple<VMDefn>
+public defmulti sub-funcs (p:VMPackage, g:Tuple<VMDefn>) -> VMPackage
+public defmulti methods (p:VMPackage) -> Tuple<VMMethod>
+public defmulti externs (p:VMPackage) -> Tuple<VMExtern>
+public defmulti extern-defns (p:VMPackage) -> Tuple<VMExternDefn>
+public defmulti debug-name-table (p:VMPackage) -> VMDebugNameTable
+public defmulti debug-table (p:VMPackage) -> VMDebugInfoTable
+public defmulti safepoint-table (p:VMPackage) -> VMSafepointTable
+
+public defstruct #VMPackage <: VMPackage :
+  packageio: PackageIO with: (as-method => true)
+  init: Int|False with: (as-method => true)
+  globals: Tuple<VMGlobal> with: (updater => sub-globals, as-method => true)
+  datas: Tuple<VMData> with: (updater => sub-datas, as-method => true)
+  consts: Tuple<VMConst> with: (as-method => true)
+  classes: Tuple<VMClass> with: (as-method => true)
+  funcs: Tuple<VMDefn> with: (updater => sub-funcs, as-method => true)
+  methods: Tuple<VMMethod> with: (as-method => true)
+  externs: Tuple<VMExtern> with: (as-method => true)
+  extern-defns: Tuple<VMExternDefn> with: (as-method => true)
+  debug-name-table: VMDebugNameTable with: (as-method => true)
+  debug-table: VMDebugInfoTable with: (as-method => true)
+  safepoint-table: VMSafepointTable with: (as-method => true)
+with:
+  constructor => VMPackage
 
 ;A value that can be accessed directly within an instruction.
 public deftype VMImm
@@ -134,10 +154,20 @@ public defstruct VMDef :
   type: VMType
   local: Int with: (default => 0, updater => sub-local)
 
-public defstruct VMDefn :
-  id: Int with: (updater => sub-id)
-  dependencies: Tuple<Int> with: (default => [], updater => sub-dependencies)
-  func: VMFunction with: (updater => sub-func)
+public deftype VMDefn
+public defmulti id (d:VMDefn) -> Int
+public defmulti sub-id (d:VMDefn, id:Int) -> VMDefn
+public defmulti dependencies (d:VMDefn) -> Tuple<Int>
+public defmulti sub-dependencies (d:VMDefn, dependencies:Tuple<Int>) -> VMDefn
+public defmulti func (d:VMDefn) -> VMFunction
+public defmulti sub-func (d:VMDefn, func:VMFunction) -> VMDefn
+
+public defstruct #VMDefn <: VMDefn :
+  id: Int with: (updater => sub-id, as-method => true)
+  dependencies: Tuple<Int> with: (default => [], updater => sub-dependencies, as-method => true)
+  func: VMFunction with: (updater => sub-func, as-method => true)
+with:
+  constructor => VMDefn
 
 ;Indicates that the function 'fid' is called externally.
 ;- lbl: If given, the static label of this function. When statically-compiled,

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -4292,6 +4292,13 @@ defn ensure-divide-non-zero (i:Long) :
   #if-defined(OPTIMIZE) : (false)
   #else : (fatal("Cannot divide by zero.") when i == 0L)
 
+protected defn ensure-initialized (x, name:Symbol) :
+  #if-not-defined(OPTIMIZE) :
+    if x is Uninitialized :
+      fatal("Field %_ has not been initialized." % [name])
+  #else :
+    false
+
 protected defn ensure-index-in-bounds (xs:Lengthable, i:Int) :
   #if-defined(OPTIMIZE) :
     false

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -4292,12 +4292,8 @@ defn ensure-divide-non-zero (i:Long) :
   #if-defined(OPTIMIZE) : (false)
   #else : (fatal("Cannot divide by zero.") when i == 0L)
 
-protected defn ensure-initialized (x, name:Symbol) :
-  #if-not-defined(OPTIMIZE) :
-    if x is Uninitialized :
-      fatal("Field %_ has not been initialized." % [name])
-  #else :
-    false
+protected defn uninitialized-field-error (name:Symbol) :
+  fatal("Field %_ has not been initialized." % [name])
 
 protected defn ensure-index-in-bounds (xs:Lengthable, i:Int) :
   #if-defined(OPTIMIZE) :


### PR DESCRIPTION
switch to using lostanza deftypes in the expansion of defstruct instead of using defn + new.  this removes the need for Box's for mutable fields and reduces the space and time overheads of them.  the downside is that defstruct no longer produces a hi-stanza deftype so one can't subtype the defstruct type.  you can of course work around this by creating an abstract deftype that the defstruct subtypes and that other types can subtype.