### PR TITLE
Jb/new fast arrays

### DIFF
--- a/compiler/algorithms.stanza
+++ b/compiler/algorithms.stanza
@@ -39,7 +39,7 @@ defmulti to-tuple (s:FIntSet) -> Tuple<Int>
 defmulti get (s:FIntSet, x:Int) -> True|False
 
 defn FIntSet (N:Int) :
-  val mark = Array<True|False>(N, false)
+  val mark = RawArray<True|False>(N, false)
   val accum = Vector<Int>()
   new FIntSet :
     defmethod add (this, x:Int) :
@@ -90,7 +90,7 @@ public defn bipartite-closure (entries0:Seqable<KeyValue<Int, Tuple<Int>>>) ->
     get-id(key(e)) => map(get-id,value(e))
 
   ;Track solutions
-  val solns = Array<Tuple<Int>|False>(num-ids(), false)
+  val solns = RawArray<Tuple<Int>|False>(num-ids(), false)
 
   ;Forward substitution (Recursively substitutes solutions)
   val visited = FIntSet(num-ids())

--- a/compiler/dispatch-dag.stanza
+++ b/compiler/dispatch-dag.stanza
@@ -512,7 +512,7 @@ defmethod compare (a:IntervalEvent, b:IntervalEvent) :
 
 defn topo-order (n:Int, ancestors:Table<Int,List<Int>>) -> Tuple<Int> :
   val list = Vector<Int>()
-  val visited = Array<True|False>(n,false)
+  val visited = RawArray<True|False>(n,false)
   let loop (xs:Seqable<Int> = 0 to n):
     for x in xs do :
       if not visited[x] :
@@ -712,7 +712,7 @@ defmethod print (o:OutputStream, e:DagEntry) :
 ;============================================================
 
 defn all-cases (dag:Dag) :
-  val case = Array<Int>(depth(dag), 0)
+  val case = RawArray<Int>(depth(dag), 0)
   generate<KeyValue<Tuple<Int>,Soln>> :
     let visit (s:Int|Soln = 0) :
       match(s) :
@@ -755,7 +755,7 @@ public defn compute-dispatch-dag (btable:BranchTable, topological?:True|False) -
 
 public defn all-solns (dag:Dag, case:Tuple<Arg>, include-amb?:True|False) -> Tuple<Soln> :
   ;Track whether a dagentry has already been processed
-  val visited = Array<True|False>(length(entries(dag)), false)
+  val visited = RawArray<True|False>(length(entries(dag)), false)
 
   ;Accumulate all the reachable solutions
   val solns = HashSet<Soln>()

--- a/compiler/hash.stanza
+++ b/compiler/hash.stanza
@@ -8,17 +8,17 @@ defpackage stz/hash :
 
 # Fundamental State #
 
-  buckets:Array<List<KeyValue<Int,T>>>
+  buckets:RawArray<List<KeyValue<Int,T>>>
   bucket-indices:IntArray
   dtable:IntArray
-  etable:Array<KeyValue<Int,T>|False>  
+  etable:RawArray<KeyValue<Int,T>|False>  
 
 # Put entries into buckets #
 
 Input:
   d0:Int
 Output:
-  buckets:Array<List<KeyValue<Int,T>>> (implicit)
+  buckets:RawArray<List<KeyValue<Int,T>>> (implicit)
   bucket-indices:IntArray (implicit)
 
 # Computing a spreading d #
@@ -54,7 +54,7 @@ Input :
   start: Int
 Output :
   dtable:IntArray (implicit)
-  etable:Array<KeyValue<Int,T>|False> (implicit)
+  etable:RawArray<KeyValue<Int,T>|False> (implicit)
 
 Given the starting index of the single-item buckets, put their entries
 into dtable and etable.
@@ -64,7 +64,7 @@ into dtable and etable.
 Output :
   d0:Int
   dtable:IntArray (implicit)
-  etable:Array<KeyValue<Int,T>|False> (implicit)
+  etable:RawArray<KeyValue<Int,T>|False> (implicit)
 
 Returns the initial d0 used for hashing into first-level table.
 
@@ -87,18 +87,18 @@ public defn PerfectHashTable<?T> (entries0:Collection<KeyValue<Int,?T>> & Length
   val n = length(entries0)
 
   ;Hold buckets and sorted bucket indices
-  var buckets:Array<List<KeyValue<Int,T>>>
+  var buckets:RawArray<List<KeyValue<Int,T>>>
   var bucket-indices:IntArray
   var dtable:IntArray
-  var etable:Array<KeyValue<Int,T>|False>
+  var etable:RawArray<KeyValue<Int,T>|False>
 
   ;Put all entries in buckets
   defn put-in-buckets (d0:Int) :
     ;Initialize all tables
-    buckets = Array<List<KeyValue<Int,T>>>(n, List())
+    buckets = RawArray<List<KeyValue<Int,T>>>(n, List())
     bucket-indices = to-intarray(0 to n)
     dtable = IntArray(n, 0)
-    etable = Array<KeyValue<Int,T>|False>(n, false)
+    etable = RawArray<KeyValue<Int,T>|False>(n, false)
 
     ;Put in buckets
     for e in entries0 do :

--- a/compiler/hash.stanza
+++ b/compiler/hash.stanza
@@ -96,7 +96,7 @@ public defn PerfectHashTable<?T> (entries0:Collection<KeyValue<Int,?T>> & Length
   defn put-in-buckets (d0:Int) :
     ;Initialize all tables
     buckets = Array<List<KeyValue<Int,T>>>(n, List())
-    bucket-indices = to-array<Int>(0 to n)
+    bucket-indices = to-intarray(0 to n)
     dtable = IntArray(n, 0)
     etable = Array<KeyValue<Int,T>|False>(n, false)
 

--- a/compiler/hash.stanza
+++ b/compiler/hash.stanza
@@ -9,8 +9,8 @@ defpackage stz/hash :
 # Fundamental State #
 
   buckets:Array<List<KeyValue<Int,T>>>
-  bucket-indices:Array<Int>
-  dtable:Array<Int>
+  bucket-indices:IntArray
+  dtable:IntArray
   etable:Array<KeyValue<Int,T>|False>  
 
 # Put entries into buckets #
@@ -19,7 +19,7 @@ Input:
   d0:Int
 Output:
   buckets:Array<List<KeyValue<Int,T>>> (implicit)
-  bucket-indices:Array<Int> (implicit)
+  bucket-indices:IntArray (implicit)
 
 # Computing a spreading d #
 
@@ -53,7 +53,7 @@ buckets. If the operation fails, then we return false.
 Input :
   start: Int
 Output :
-  dtable:Array<Int> (implicit)
+  dtable:IntArray (implicit)
   etable:Array<KeyValue<Int,T>|False> (implicit)
 
 Given the starting index of the single-item buckets, put their entries
@@ -63,7 +63,7 @@ into dtable and etable.
 
 Output :
   d0:Int
-  dtable:Array<Int> (implicit)
+  dtable:IntArray (implicit)
   etable:Array<KeyValue<Int,T>|False> (implicit)
 
 Returns the initial d0 used for hashing into first-level table.
@@ -88,8 +88,8 @@ public defn PerfectHashTable<?T> (entries0:Collection<KeyValue<Int,?T>> & Length
 
   ;Hold buckets and sorted bucket indices
   var buckets:Array<List<KeyValue<Int,T>>>
-  var bucket-indices:Array<Int>
-  var dtable:Array<Int>
+  var bucket-indices:IntArray
+  var dtable:IntArray
   var etable:Array<KeyValue<Int,T>|False>
 
   ;Put all entries in buckets
@@ -97,7 +97,7 @@ public defn PerfectHashTable<?T> (entries0:Collection<KeyValue<Int,?T>> & Length
     ;Initialize all tables
     buckets = Array<List<KeyValue<Int,T>>>(n, List())
     bucket-indices = to-array<Int>(0 to n)
-    dtable = Array<Int>(n, 0)
+    dtable = IntArray(n, 0)
     etable = Array<KeyValue<Int,T>|False>(n, false)
 
     ;Put in buckets
@@ -109,7 +109,7 @@ public defn PerfectHashTable<?T> (entries0:Collection<KeyValue<Int,?T>> & Length
     qsort!({(- length(buckets[_]))}, bucket-indices)
 
   ;Computing a spreading d
-  val dset = Array<Int>(n, -1)
+  val dset = IntArray(n, -1)
   val dcounter = to-seq(0 to false)
   defn compute-d (keys:Collection<Int>, max-d:Int) :    
     let loop-d (d:Int = 2) :

--- a/compiler/jit-encoder.stanza
+++ b/compiler/jit-encoder.stanza
@@ -190,7 +190,7 @@ defn Registers (backend:Backend) -> Registers :
   val callc-freturn = freg-by-number[callc-fret(backend)]
 
   ;Assign registers
-  val reg-assignments-map = Array<Gp>(VMRegItem-length)
+  val reg-assignments-map = RawArray<Gp>(VMRegItem-length)
   for entry in reg-assignments do :
     val i = to-int(key(entry))
     reg-assignments-map[i] = value(entry)

--- a/compiler/overlap-table.stanza
+++ b/compiler/overlap-table.stanza
@@ -23,10 +23,10 @@ public defn OverlapTable (n:Int, num-coords:Int) -> OverlapTable :
     fatal("Empty OverlapTable")
 
   ;Create the layers for each coordinate.
-  val layers = Array<CoordLayer>(num-coords)
+  val layers = RawArray<CoordLayer>(num-coords)
   for i in 0 to num-coords do :
     layers[i] = CoordLayer(Vector<List<Int>>(),
-                           Array<Int|False>(n,false),
+                           RawArray<Int|False>(n,false),
                            HashSet<[Int,Int]>())
 
   ;Create the key for the pairwise table.
@@ -40,7 +40,7 @@ public defn OverlapTable (n:Int, num-coords:Int) -> OverlapTable :
 
     ;Partition a single group using the given layer of disjoint groups.
     defn partition (group:List<Int>, layer:CoordLayer) -> Seqable<List<Int>> :
-      val partitions = Array<List<Int>>(length(groups(layer)), List())
+      val partitions = RawArray<List<Int>>(length(groups(layer)), List())
       for v in group do :
         val i = markers(layer)[v]
         match(i:Int) :
@@ -177,7 +177,7 @@ public defn OverlapTable (n:Int, num-coords:Int) -> OverlapTable :
 ;- pairwise: the pairwise relations in the layer.
 defstruct CoordLayer :
   groups:Vector<List<Int>>  
-  markers:Array<Int|False>
+  markers:RawArray<Int|False>
   pairwise:HashSet<[Int,Int]>
 
 ;Return true if the given value in the layer is not part

--- a/compiler/read-lang-engine.stanza
+++ b/compiler/read-lang-engine.stanza
@@ -166,7 +166,7 @@ public defn read (form, forms:Tuple<Form>) :
             map(read-prod?{_, prod}, form)
 
          ;Read all values according to their field descriptors.
-         val values = Array<?>(n)
+         val values = RawArray<?>(n)
          defn* loop (i:Int, form:List) :
             if i < n :
                values[i] = match(fs[i]) :

--- a/compiler/reg-alloc.stanza
+++ b/compiler/reg-alloc.stanza
@@ -1158,7 +1158,7 @@ defn holds-named-vars? (i:Ins) -> True|False :
 
 defn liveness-analysis () :
   ;Clear state
-  val var-uses = Array<List<VarUse>>(nvars(), List())
+  val var-uses = RawArray<List<VarUse>>(nvars(), List())
   val block-defs = BitMatrix(nblocks(), nvars())
 
   ;Mark uses and defs
@@ -1277,7 +1277,7 @@ defn add-annotations (blk:Block, b:Int) :
   ;===========================
   ;==== Liveness Tracking ====
   ;===========================
-  val usages = Array<False|Int>(nvars(), false)
+  val usages = RawArray<False|Int>(nvars(), false)
   val live-dirty = Vector<Int>()
 
   defn mark-used (n:Int, dist:Int) :
@@ -1299,10 +1299,10 @@ defn add-annotations (blk:Block, b:Int) :
   ;==== Preference Tracking ====
   ;=============================
   ;The remaining code prefers the variable to be loaded.
-  val prefers-load = Array<True|False>(nvars(), true)
+  val prefers-load = RawArray<True|False>(nvars(), true)
 
   ;The remaining code expects the variable to be saved.
-  val requires-save = Array<True|False>(nvars(), false)
+  val requires-save = RawArray<True|False>(nvars(), false)
 
   ;============================
   ;==== Instruction Buffer ====
@@ -1491,7 +1491,7 @@ defn allocate-classes (blk:Block, b:Int, backend:Backend) :
   ;========================
   ;==== Usage Tracking ====
   ;========================
-  val usages = Array<Int|False>(nvars(), false)
+  val usages = RawArray<Int|False>(nvars(), false)
   defn mark-next-use (n:Int, pos:Int) :
     usages[n] = pos
   defn next-use (n:Int) :
@@ -1646,9 +1646,9 @@ defn register-assignment (blk:Block, b:Int, backend:Backend) :
   ;===========================
   ;==== Register Tracking ====
   ;===========================
-  val var-locs = Array<False|Reg|FReg>(nvars(), false)
-  val reg-slots = Array<False|Int>(num-regs(backend), false)
-  val freg-slots = Array<False|Int>(num-fregs(backend), false)
+  val var-locs = RawArray<False|Reg|FReg>(nvars(), false)
+  val reg-slots = RawArray<False|Int>(num-regs(backend), false)
+  val freg-slots = RawArray<False|Int>(num-fregs(backend), false)
   val reg-list = FreeList(num-regs(backend))
   val freg-list = FreeList(num-fregs(backend))
 
@@ -1857,7 +1857,7 @@ defn register-assignment (blk:Block, b:Int, backend:Backend) :
   if not empty?(in-ports) :
     ;Retrieve output ports of predecessor block
     val pred = find!({_ < b}, PREDECESSORS[b])
-    val port-table = Array<Port>(nvars())
+    val port-table = RawArray<Port>(nvars())
     for p in OUT-PORTS[pred] do : port-table[n(p)] = p
     ;Calculate port locations
     val port-assigns = to-list $ for p in in-ports seq? :
@@ -2050,7 +2050,7 @@ defn stack-intervals () -> Seq<Interval> :
       note-usage(v, in-port-pos[b])
 
   defn sorted-intervals () :
-    val ints = Array<List<Interval>>(num-pos, List())
+    val ints = RawArray<List<Interval>>(num-pos, List())
     defn add-interval (i:Int, x:Interval) :
       ints[i] = cons(x, ints[i])
     for v in 0 to nvars() do :
@@ -2116,7 +2116,7 @@ defn stack-map () :
   ;===========================
   val occupied-locs = Vector<True|False>()
   val loc-types = Vector<VMType>()
-  val var-locs = Array<False|Int>(nvars(), false)
+  val var-locs = RawArray<False|Int>(nvars(), false)
 
   ;Get next available location
   defn available-loc (t:VMType) :
@@ -2177,7 +2177,7 @@ defn stack-map () :
 
 defmethod print (o:OutputStream, s:StackMap) :
   ;Discover vars per location
-  val vars = Array<List<Int>>(length(locations(s)), List())
+  val vars = RawArray<List<Int>>(length(locations(s)), List())
   for v in 0 to nvars() do :
     val loc = location(s, v)
     match(loc:Int) :
@@ -2192,7 +2192,7 @@ defn num-locations (s:StackMap) :
   length(locations(s))
 
 defn refmask (s:StackMap) :
-  val mask = Array<True|False>(size(s) / 8, false)
+  val mask = RawArray<True|False>(size(s) / 8, false)
   for (t in locations(s), offset in offsets(s)) do :
     match(t:VMRef) : mask[offset / 8] = true
   [length(mask), to-bitmask(mask)]
@@ -2212,14 +2212,14 @@ defn ref-offsets (s:StackMap) :
 ;=====================
 defn roots (nreg:Int, xs:List<Int>, ys:List<Int>) :
   ;Compute all sources
-  val srcs = Array<False|Int>(nreg, false)
-  val dsts = Array<List<Int>>(nreg, List())
+  val srcs = RawArray<False|Int>(nreg, false)
+  val dsts = RawArray<List<Int>>(nreg, List())
   for (x in xs, y in ys) do :
     srcs[x] = y
     dsts[y] = cons(x, dsts[y])
 
   ;Compute the source
-  val visited = Array<True|False>(nreg, false)
+  val visited = RawArray<True|False>(nreg, false)
   defn root (x:Int) :
     visit(x)
     match(srcs[x]) :
@@ -2244,11 +2244,11 @@ defn shuffle (nreg:Int, xs:List<Int>, ys:List<Int>,
               emit-move: (Int, Int) -> False
               emit-swap: (Int, Int) -> False) :
   ;Compute all destinations
-  val dsts = Array<List<Int>>(nreg, List())
+  val dsts = RawArray<List<Int>>(nreg, List())
   for (x in xs, y in ys) do :
     dsts[y] = cons(x, dsts[y])
 
-  val visited = Array<False|True>(nreg, false)
+  val visited = RawArray<False|True>(nreg, false)
   defn move (src:Int) -> True|False :
     ;Mark visited
     visited[src] = true
@@ -2276,11 +2276,11 @@ defn shuffle (nreg:Int, xs:List<Int>, ys:List<Int>,
 defn shuffle (nreg:Int, xs:List<Int>, ys:List<Int>, swap:Int
               emit-move: (Int, Int) -> False) :
   ;Compute destinations
-  val dsts = Array<List<Int>>(nreg, List())
+  val dsts = RawArray<List<Int>>(nreg, List())
   for (x in xs, y in ys) do :
     dsts[y] = cons(x, dsts[y])
 
-  val visited = Array<False|True>(nreg, false)
+  val visited = RawArray<False|True>(nreg, false)
   defn move (src:Int) -> True|False :
     ;Mark visited
     visited[src] = true
@@ -2364,7 +2364,7 @@ defn collapse-blocks () :
     val fshuffles = Vector<KeyValue<Int,Int>>()
 
     ;Populate port table
-    val port-table = Array<Port>(nvars())
+    val port-table = RawArray<Port>(nvars())
     for y in ys do : port-table[n(y)] = y
 
     ;Populate instruction buffers

--- a/compiler/reg-alloc.stanza
+++ b/compiler/reg-alloc.stanza
@@ -1050,7 +1050,7 @@ defn unused-regs (used:Seqable<Loc>, num:Int, backend:Backend) -> Vector<Reg> :
 
 defn remove-critical-edges () :
   ;Count predecessors
-  val num-preds-table = Array<Int>(nblocks(),0)
+  val num-preds-table = IntArray(nblocks(),0)
   for (b in BLOCKS, i in 0 to false) do :
     for n in next(b) do :
       num-preds-table[n] = 1 + num-preds-table[n]
@@ -1178,8 +1178,8 @@ defn liveness-analysis () :
   ;Propagate liveness
   clear(IN-PORTS, nblocks(), List())
   clear(OUT-PORTS, nblocks(), List())
-  val in-dists = Array<Int>(nblocks(), INT-MAX)
-  val out-dists = Array<Int>(nblocks(), INT-MAX)
+  val in-dists = IntArray(nblocks(), INT-MAX)
+  val out-dists = IntArray(nblocks(), INT-MAX)
   val in-dirty = Vector<Int>()
   val out-dirty = Vector<Int>()
 
@@ -1205,8 +1205,8 @@ defn liveness-analysis () :
 
 ;Mark that variable v is live-in to block b with distance d
 lostanza defn mark-live-in (defs:ref<BitMatrix>,
-                            in-dists:ref<Array<Int>>,
-                            out-dists:ref<Array<Int>>,
+                            in-dists:ref<IntArray>,
+                            out-dists:ref<IntArray>,
                             in-dirty:ref<Vector<Int>>,
                             out-dirty:ref<Vector<Int>>,
                             b:ref<Int>,
@@ -1237,8 +1237,8 @@ lostanza defn mark-live-in (defs:ref<BitMatrix>,
 
 ;Mark that variable v is live-out from block b with distance d
 lostanza defn mark-live-out (defs:ref<BitMatrix>,
-                             in-dists:ref<Array<Int>>,
-                             out-dists:ref<Array<Int>>,
+                             in-dists:ref<IntArray>,
+                             out-dists:ref<IntArray>,
                              in-dirty:ref<Vector<Int>>,
                              out-dirty:ref<Vector<Int>>,
                              b:ref<Int>,
@@ -2020,8 +2020,8 @@ defn stack-intervals () -> Seq<Interval> :
   ;========================
   ;==== Port Positions ====
   ;========================
-  val in-port-pos = Array<Int>(nblocks())
-  val out-port-pos = Array<Int>(nblocks())
+  val in-port-pos = IntArray(nblocks())
+  val out-port-pos = IntArray(nblocks())
   val num-pos = let :
     val pos-counter = Counter(0)
     for (blk in BLOCKS, b in 0 to false) do :
@@ -2032,8 +2032,8 @@ defn stack-intervals () -> Seq<Interval> :
   ;===========================
   ;==== Interval Tracking ====
   ;===========================
-  val var-start = Array<Int>(nvars(), INT-MAX)
-  val var-end = Array<Int>(nvars(), INT-MIN)
+  val var-start = IntArray(nvars(), INT-MAX)
+  val var-end = IntArray(nvars(), INT-MIN)
 
   defn note-usage (v:Int, i:Int) :
     var-start[v] = min(i, var-start[v])
@@ -2423,7 +2423,7 @@ defn collapse-blocks () :
   ;======================
   ;==== Block Labels ====
   ;======================
-  val lbls = Array<Int>(nblocks())
+  val lbls = IntArray(nblocks())
   lbls[0 to false] = repeatedly(unique-id{})
 
   ;===================

--- a/compiler/set-simplifier.stanza
+++ b/compiler/set-simplifier.stanza
@@ -191,9 +191,9 @@ defn dnf-form (term:Term) -> Term :
       (t) : [t]
 
   ;Permutations
-  defn permutations (return:Array<Int> -> ?, lengths:Tuple<Int>) :
+  defn permutations (return:IntArray -> ?, lengths:Tuple<Int>) :
     val dims = length(lengths)
-    val indices = Array<Int>(dims, 0)
+    val indices = IntArray(dims, 0)
     let loop (d:Int = 0) :
       if d < dims :
         for i in 0 to lengths[d] do :
@@ -203,7 +203,7 @@ defn dnf-form (term:Term) -> Term :
         return(indices)
 
   ;Retrieve the given indices in the given term tuple.
-  defn gather-intersection-vars (termss:Tuple<Tuple<Term>>, indices:Array<Int>) -> Seq<Term> :
+  defn gather-intersection-vars (termss:Tuple<Tuple<Term>>, indices:IntArray) -> Seq<Term> :
     for (i in indices, terms in termss) seq-cat :
       match(terms[i]) :
         (t:Intersection) : /terms(t)

--- a/compiler/shortest-paths.stanza
+++ b/compiler/shortest-paths.stanza
@@ -93,8 +93,8 @@ defn restrict-successors (successors:Int -> Seqable<Int>,
 ;============================================================
 
 defstruct LeavesAndCycles :
-  cycles:Array<Tuple<Int>|False>
-  leaves:Array<True|False>  
+  cycles:RawArray<Tuple<Int>|False>
+  leaves:RawArray<True|False>  
 
 defn compute-leaves-and-cycles (-- num-nodes:Int,
                                    successors:Int -> Seqable<Int>) -> LeavesAndCycles :
@@ -104,8 +104,8 @@ defn compute-leaves-and-cycles (-- num-nodes:Int,
       node => to-list(successors(node))
 
   ;Compute cycle indices.
-  val cycles = Array<Tuple<Int>|False>(num-nodes, false)
-  val cycle-indices = Array<Int|False>(num-nodes, false)
+  val cycles = RawArray<Tuple<Int>|False>(num-nodes, false)
+  val cycle-indices = RawArray<Int|False>(num-nodes, false)
   for component in components do :
     match(component:List<Int>) :
       if length(component) > 1 :
@@ -121,7 +121,7 @@ defn compute-leaves-and-cycles (-- num-nodes:Int,
       (f:False) : node
 
   ;Compute leaves.
-  val leaves = Array<True|False>(num-nodes, true)
+  val leaves = RawArray<True|False>(num-nodes, true)
   for node in 0 to num-nodes do :
     val node-r = representative-node(node)
     for succ in successors(node) do :
@@ -145,11 +145,11 @@ defn compute-leaves-and-cycles (-- num-nodes:Int,
 defn shortest-paths-children (-- num-nodes:Int,
                                  source:Int,
                                  successors:Int -> Seqable<Int>,
-                                 leaf?:Int -> True|False) -> Array<List<Int>> :
+                                 leaf?:Int -> True|False) -> RawArray<List<Int>> :
 
-  val visited = Array<True|False>(num-nodes, false)
+  val visited = RawArray<True|False>(num-nodes, false)
   
-  val children = Array<List<Int>>(num-nodes, List())
+  val children = RawArray<List<Int>>(num-nodes, List())
 
   val queue = Queue<Int>()
 
@@ -180,7 +180,7 @@ defn shortest-paths-children (-- num-nodes:Int,
 ;Compute shortest paths tree. Discard any branches that
 ;do not end in a leaf?.
 defn shortest-paths (-- source:Int,
-                        children:Array<List<Int>>,
+                        children:RawArray<List<Int>>,
                         leaf?:Int -> True|False) -> PathTree :
   defn path-tree (node:Int) -> PathTree|False :
     if empty?(children[node]) :
@@ -198,11 +198,11 @@ defn shortest-paths (-- source:Int,
 ;Compute the backedges in a traversal from the given source.
 defn backedges (-- num-nodes:Int,
                    source:Int,
-                   successors:Int -> Seqable<Int>) -> [Vector<KeyValue<Int,Int>>, Array<Int|False>] :
+                   successors:Int -> Seqable<Int>) -> [Vector<KeyValue<Int,Int>>, RawArray<Int|False>] :
   val backedges = Vector<KeyValue<Int,Int>>()
-  val parents = Array<Int|False>(num-nodes, false)
-  val visiting = Array<True|False>(num-nodes, false)
-  val visited = Array<True|False>(num-nodes, false)
+  val parents = RawArray<Int|False>(num-nodes, false)
+  val visiting = RawArray<True|False>(num-nodes, false)
+  val visited = RawArray<True|False>(num-nodes, false)
   let loop (node:Int = source, parent:Int|False = false) :
     if visited[node] :
       if visiting[node] :
@@ -217,7 +217,7 @@ defn backedges (-- num-nodes:Int,
 
 ;Convert the backedges into cycles.
 defn make-cycles (-- backedges:Vector<KeyValue<Int,Int>>,
-                     parents:Array<Int|False>) -> Seqable<Tuple<Int>> :
+                     parents:RawArray<Int|False>) -> Seqable<Tuple<Int>> :
   defn chain (-- leaf:Int, root:Int) -> List<Int> :
     if leaf == root : List(leaf)
     else : cons(leaf, chain(leaf = parents[leaf] as Int, root = root))

--- a/compiler/stitcher.stanza
+++ b/compiler/stitcher.stanza
@@ -362,7 +362,7 @@ public defn Stitcher (packages:Collection<VMPackage>, bindings:Bindings|False, s
         (c:VMAbstractClass) : VMAbstractClass(gid(id(c)), gids(parents(c)), gids(children(c)))
 
     ;Categorize class definitions
-    val builtin-classes = Array<VMArrayClass|VMLeafClass>(NUM-BUILTIN-CONCRETE-TYPES)
+    val builtin-classes = RawArray<VMArrayClass|VMLeafClass>(NUM-BUILTIN-CONCRETE-TYPES)
     val concrete-classes = Vector<VMArrayClass|VMLeafClass>()
     val abstract-classes = Vector<VMAbstractClass>()
     for p in packages do :

--- a/compiler/type-fargs.stanza
+++ b/compiler/type-fargs.stanza
@@ -241,7 +241,7 @@ public defn arg-pattern (arities:FnArities, expected:Tuple<FArg>, num-given:Int)
 public defn instantiate-pattern<?T> (fargs:Tuple<FArg<?T>>
                                      pat:ArgPattern,
                                      wrap-tuple:T -> T) -> Tuple<T> :
-  val ret = Array<T>(num-args(pat))
+  val ret = RawArray<T>(num-args(pat))
   for (a in args(pat), farg in fargs) do :
     match(a, type(a)) :
       (a:VarArg, u:GivenArg) :

--- a/compiler/vm-table.stanza
+++ b/compiler/vm-table.stanza
@@ -363,7 +363,7 @@ public lostanza defn load-data (vmt:ref<VMTable>, d:ref<VMData>) -> ref<False> :
 public defn load-datas (vmt:VMTable, ds:Tuple<VMData>) :
   do(load-data{vmt, _}, ds)
 
-lostanza defn non-negative? (xs:ref<Array<Int>>, i:ref<Int>) -> long :
+lostanza defn non-negative? (xs:ref<StableIntArray>, i:ref<Int>) -> long :
   val l = length(xs).value
   if i.value < l :
     if get(xs,i).value >= 0 : return 1L

--- a/core/collections.stanza
+++ b/core/collections.stanza
@@ -40,7 +40,7 @@ defmethod print (o:OutputStream, x:SetItem) :
 ;Binary search
 ;Returns n such that the first n numbers in xs < v
 defn bsearch<?T,?S> (less?: (T, S) -> True|False,
-                     xs:Array<?T>,
+                     xs:RawArray<?T>,
                      n:Int,
                      v:?S) -> Int :
   ;All items with index less than i are known to be smaller than v.
@@ -94,11 +94,11 @@ public defmulti set-length<?T> (v:Vector<?T>, length:Int, x:T) -> False
 
 public defn Vector<T> (cap:Int) -> Vector<T> :
    core/ensure-non-negative("capacity", cap)
-   var array = Array<T>(cap)
+   var array = RawArray<T>(cap)
    var size = 0
 
    defn set-capacity (c:Int) :
-      val new-array = Array<T>(c)
+      val new-array = RawArray<T>(c)
       new-array[0 to size] = array
       array = new-array
          
@@ -179,7 +179,7 @@ public defn Vector<T> (cap:Int) -> Vector<T> :
       defmethod clear (this, n:Int, x0:T) :
          if length(array) < n :
             val cap = max(n, 2 * length(array))
-            array = Array<T>(cap, x0)
+            array = RawArray<T>(cap, x0)
             size = n
          else :
             set-all(array, 0 to n, x0)
@@ -280,13 +280,13 @@ public defmulti peek<?T> (q:Queue<?T>) -> T
 public defn Queue<T> (initial-cap:Int) -> Queue<T> :
    core/ensure-non-negative("capacity", initial-cap)
    var cap:Int = next-pow2(initial-cap)
-   var array:Array<T> = Array<T>(cap)
+   var array:RawArray<T> = RawArray<T>(cap)
    var begin:Int = 0
    var size:Int = 0
 
    defn ensure-capacity (c:Int) :
       defn set-capacity (c:Int) :
-         val new-array = Array<T>(c)
+         val new-array = RawArray<T>(c)
          for i in 0 to size do :
             new-array[i] = array[wrapped-index(i)]
          array = new-array
@@ -448,7 +448,7 @@ public defn HashTable<K,V> (cap0:Int
     cap = c
     limit = c * 3 / 4
     mask = cap - 1
-    slots = Array<Sentinel|TableItem<K,V>|Array<TableItem<K,V>>>(cap, sentinel())
+    slots = RawArray<Sentinel|TableItem<K,V>|RawArray<TableItem<K,V>>>(cap, sentinel())
     sizes = IntArray(cap, 0)
     size = 0
 
@@ -472,11 +472,11 @@ public defn HashTable<K,V> (cap0:Int
     match?(a, hash(b), key(b))
 
   ;Find number of items whose hash is less than h
-  defn num-before (xs:Array<TableItem<K,V>>, n:Int, h:Int) :
+  defn num-before (xs:RawArray<TableItem<K,V>>, n:Int, h:Int) :
     bsearch({hash(_) < _}, xs, n, h)
 
   ;Look for item with given hash and key starting from i
-  defn* index-of-item (xs:Array<TableItem<K,V>>, i:Int, n:Int, h:Int, k:K) :
+  defn* index-of-item (xs:RawArray<TableItem<K,V>>, i:Int, n:Int, h:Int, k:K) :
     if i < n :
       val x = xs[i]
       if hash(x) == h :
@@ -484,18 +484,18 @@ public defn HashTable<K,V> (cap0:Int
         else : index-of-item(xs, i + 1, n, h, k)
 
   ;Shift items in xs from i to n right by one element
-  defn* shift-right (xs:Array<TableItem<K,V>>, i:Int, n:Int) :
+  defn* shift-right (xs:RawArray<TableItem<K,V>>, i:Int, n:Int) :
     for j in n to i by -1 do :
       xs[j] = xs[j - 1]
 
   ;Shift items in xs from (i + 1) to n left by one element
-  defn* shift-left (xs:Array<TableItem<K,V>>, i:Int, n:Int) :
+  defn* shift-left (xs:RawArray<TableItem<K,V>>, i:Int, n:Int) :
     for j in i to (n - 1) do :
       xs[j] = xs[j + 1]    
 
   ;Copy to new array with hole in position i
-  defn* copy-with-hole (xs:Array<TableItem<K,V>>, i:Int, n:Int) :
-    val xs* = Array<TableItem<K,V>>(length(xs) * 2)
+  defn* copy-with-hole (xs:RawArray<TableItem<K,V>>, i:Int, n:Int) :
+    val xs* = RawArray<TableItem<K,V>>(length(xs) * 2)
     xs*[0 to i] = xs[0 to i]
     xs*[(i + 1) to (n + 1)] = xs[i to n]
     xs*
@@ -516,7 +516,7 @@ public defn HashTable<K,V> (cap0:Int
     do(put, items)
 
   defn create-bucket (slot:Int, x0:TableItem<K,V>, x1:TableItem<K,V>) :
-    val bucket = Array<TableItem<K,V>>(4)
+    val bucket = RawArray<TableItem<K,V>>(4)
     slots[slot] = bucket
     sizes[slot] = 2
     ;Populate bucket
@@ -529,7 +529,7 @@ public defn HashTable<K,V> (cap0:Int
       bucket[0] = x1
       bucket[1] = x0
 
-  defn add-to-bucket (slot:Int, bucket:Array<TableItem<K,V>>, i:Int, n:Int, x:TableItem<K,V>) :
+  defn add-to-bucket (slot:Int, bucket:RawArray<TableItem<K,V>>, i:Int, n:Int, x:TableItem<K,V>) :
     ;Case 1 of 2: Bucket has space.
     if n + 1 < length(bucket) :
       shift-right(bucket, i, n)
@@ -563,7 +563,7 @@ public defn HashTable<K,V> (cap0:Int
           create-bucket(slot, s, x)
           increment-size()
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<TableItem<K,V>>) :
+      (s:RawArray<TableItem<K,V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, hash(x))
         match(index-of-item(s, i, n, hash(x), key(x))) :
@@ -591,7 +591,7 @@ public defn HashTable<K,V> (cap0:Int
         if match?(s,h,k) : value(s)
         else : default
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<TableItem<K,V>>) :
+      (s:RawArray<TableItem<K,V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, h)
         match(index-of-item(s, i, n, h, k)) :
@@ -625,7 +625,7 @@ public defn HashTable<K,V> (cap0:Int
             increment-size()
           v          
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<TableItem<K,V>>) :
+      (s:RawArray<TableItem<K,V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, h)
         match(index-of-item(s, i, n, h, k)) :
@@ -665,7 +665,7 @@ public defn HashTable<K,V> (cap0:Int
           increment-size()
           v
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<TableItem<K,V>>) :
+      (s:RawArray<TableItem<K,V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, h)
         match(index-of-item(s, i, n, h, k)) :
@@ -691,7 +691,7 @@ public defn HashTable<K,V> (cap0:Int
       ;Case 2 of 3: Single item bucket
       (s:TableItem<K,V>) : match?(s,h,k)
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<TableItem<K,V>>) :
+      (s:RawArray<TableItem<K,V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, h)
         index-of-item(s, i, n, h, k) is Int
@@ -713,7 +713,7 @@ public defn HashTable<K,V> (cap0:Int
           decrement-size()
           true
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<TableItem<K,V>>) :
+      (s:RawArray<TableItem<K,V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, h)
         match(index-of-item(s, i, n, h, k)) :
@@ -738,7 +738,7 @@ public defn HashTable<K,V> (cap0:Int
           val v = f(key(s) => value(s))
           slots[idx] = TableItem<K,V>(hash(s), key(s), v)
         ;Case 3 of 3: Multiple item bucket
-        (s:Array<TableItem<K,V>>) :
+        (s:RawArray<TableItem<K,V>>) :
           val n = sizes[idx]
           for i in 0 to n do :
             val x = s[i]
@@ -756,7 +756,7 @@ public defn HashTable<K,V> (cap0:Int
         match(slots[idx]) :
           (s:Sentinel) : false
           (s:TableItem<K,V>) : yield(f(s))
-          (s:Array<TableItem<K,V>>) : for j in 0 to sizes[idx] do : yield(f(s[j]))
+          (s:RawArray<TableItem<K,V>>) : for j in 0 to sizes[idx] do : yield(f(s[j]))
 
   ;======================
   ;==== Table Object ====
@@ -871,7 +871,7 @@ public defn IntTable<V> (cap0:Int
     cap = c
     limit = c * 3 / 4
     mask = cap - 1
-    slots = Array<Sentinel|IntItem<V>|Array<IntItem<V>>>(cap, sentinel())
+    slots = RawArray<Sentinel|IntItem<V>|RawArray<IntItem<V>>>(cap, sentinel())
     sizes = IntArray(cap, 0)
     size = 0
 
@@ -894,28 +894,28 @@ public defn IntTable<V> (cap0:Int
     match?(a, key(b))
 
   ;Find number of items whose hash is less than h
-  defn num-before (xs:Array<IntItem<V>>, n:Int, k:Int) :
+  defn num-before (xs:RawArray<IntItem<V>>, n:Int, k:Int) :
     bsearch({key(_) < _}, xs, n, k)
 
   ;Look for item with given hash and key starting from i
-  defn* index-of-item (xs:Array<IntItem<V>>, i:Int, n:Int, k:Int) :
+  defn* index-of-item (xs:RawArray<IntItem<V>>, i:Int, n:Int, k:Int) :
     if i < n :
       val x = xs[i]
       if key(x) == k : i
 
   ;Shift items in xs from i to n right by one element
-  defn* shift-right (xs:Array<IntItem<V>>, i:Int, n:Int) :
+  defn* shift-right (xs:RawArray<IntItem<V>>, i:Int, n:Int) :
     for j in n to i by -1 do :
       xs[j] = xs[j - 1]
 
   ;Shift items in xs from (i + 1) to n left by one element
-  defn* shift-left (xs:Array<IntItem<V>>, i:Int, n:Int) :
+  defn* shift-left (xs:RawArray<IntItem<V>>, i:Int, n:Int) :
     for j in i to (n - 1) do :
       xs[j] = xs[j + 1]    
 
   ;Copy to new array with hole in position i
-  defn* copy-with-hole (xs:Array<IntItem<V>>, i:Int, n:Int) :
-    val xs* = Array<IntItem<V>>(length(xs) * 2)
+  defn* copy-with-hole (xs:RawArray<IntItem<V>>, i:Int, n:Int) :
+    val xs* = RawArray<IntItem<V>>(length(xs) * 2)
     xs*[0 to i] = xs[0 to i]
     xs*[(i + 1) to (n + 1)] = xs[i to n]
     xs*
@@ -936,7 +936,7 @@ public defn IntTable<V> (cap0:Int
     do(put, items)
 
   defn create-bucket (slot:Int, x0:IntItem<V>, x1:IntItem<V>) :
-    val bucket = Array<IntItem<V>>(4)
+    val bucket = RawArray<IntItem<V>>(4)
     slots[slot] = bucket
     sizes[slot] = 2
     ;Populate bucket
@@ -949,7 +949,7 @@ public defn IntTable<V> (cap0:Int
       bucket[0] = x1
       bucket[1] = x0
 
-  defn add-to-bucket (slot:Int, bucket:Array<IntItem<V>>, i:Int, n:Int, x:IntItem<V>) :
+  defn add-to-bucket (slot:Int, bucket:RawArray<IntItem<V>>, i:Int, n:Int, x:IntItem<V>) :
     ;Case 1 of 2: Bucket has space.
     if n + 1 < length(bucket) :
       shift-right(bucket, i, n)
@@ -983,7 +983,7 @@ public defn IntTable<V> (cap0:Int
           create-bucket(slot, s, x)
           increment-size()
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<IntItem<V>>) :
+      (s:RawArray<IntItem<V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, key(x))
         match(index-of-item(s, i, n, key(x))) :
@@ -1010,7 +1010,7 @@ public defn IntTable<V> (cap0:Int
         if match?(s,k) : value(s)
         else : default
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<IntItem<V>>) :
+      (s:RawArray<IntItem<V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, k)
         match(index-of-item(s, i, n, k)) :
@@ -1043,7 +1043,7 @@ public defn IntTable<V> (cap0:Int
             increment-size()
           v          
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<IntItem<V>>) :
+      (s:RawArray<IntItem<V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, k)
         match(index-of-item(s, i, n, k)) :
@@ -1082,7 +1082,7 @@ public defn IntTable<V> (cap0:Int
           increment-size()
           v
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<IntItem<V>>) :
+      (s:RawArray<IntItem<V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, k)
         match(index-of-item(s, i, n, k)) :
@@ -1107,7 +1107,7 @@ public defn IntTable<V> (cap0:Int
       ;Case 2 of 3: Single item bucket
       (s:IntItem<V>) : match?(s,k)
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<IntItem<V>>) :
+      (s:RawArray<IntItem<V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, k)
         index-of-item(s, i, n, k) is Int
@@ -1128,7 +1128,7 @@ public defn IntTable<V> (cap0:Int
           decrement-size()
           true
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<IntItem<V>>) :
+      (s:RawArray<IntItem<V>>) :
         val n = sizes[slot]
         val i = num-before(s, n, k)
         match(index-of-item(s, i, n, k)) :
@@ -1153,7 +1153,7 @@ public defn IntTable<V> (cap0:Int
           val v = f(key(s) => value(s))
           slots[idx] = IntItem<V>(key(s), v)
         ;Case 3 of 3: Multiple item bucket
-        (s:Array<IntItem<V>>) :
+        (s:RawArray<IntItem<V>>) :
           val n = sizes[idx]
           for i in 0 to n do :
             val x = s[i]
@@ -1171,7 +1171,7 @@ public defn IntTable<V> (cap0:Int
         match(slots[idx]) :
           (s:Sentinel) : false
           (s:IntItem<V>) : yield(f(s))
-          (s:Array<IntItem<V>>) : for j in 0 to sizes[idx] do : yield(f(s[j]))
+          (s:RawArray<IntItem<V>>) : for j in 0 to sizes[idx] do : yield(f(s[j]))
 
   ;======================
   ;==== Table Object ====
@@ -1290,7 +1290,7 @@ public defn HashSet<K> (cap0:Int
     cap = c
     limit = c * 3 / 4
     mask = cap - 1
-    slots = Array<Sentinel|SetItem<K>|Array<SetItem<K>>>(cap, sentinel())
+    slots = RawArray<Sentinel|SetItem<K>|RawArray<SetItem<K>>>(cap, sentinel())
     sizes = IntArray(cap, 0)
     size = 0
 
@@ -1315,11 +1315,11 @@ public defn HashSet<K> (cap0:Int
     key-equal?(key(a), key(b))
 
   ;Find number of items whose hash is less than h
-  defn num-before (xs:Array<SetItem<K>>, n:Int, x:SetItem<K>) :
+  defn num-before (xs:RawArray<SetItem<K>>, n:Int, x:SetItem<K>) :
     bsearch({hash(_) < hash(_)}, xs, n, x)
 
   ;Look for item with given hash and key starting from i
-  defn* index-of-item (xs:Array<SetItem<K>>, i:Int, n:Int, y:SetItem<K>) :
+  defn* index-of-item (xs:RawArray<SetItem<K>>, i:Int, n:Int, y:SetItem<K>) :
     if i < n :
       val x = xs[i]
       if hash(x) == hash(y) :
@@ -1327,18 +1327,18 @@ public defn HashSet<K> (cap0:Int
         else : index-of-item(xs, i + 1, n, y)
 
   ;Shift items in xs from i to n right by one element
-  defn* shift-right (xs:Array<SetItem<K>>, i:Int, n:Int) :
+  defn* shift-right (xs:RawArray<SetItem<K>>, i:Int, n:Int) :
     for j in n to i by -1 do :
       xs[j] = xs[j - 1]
 
   ;Shift items in xs from (i + 1) to n left by one element
-  defn* shift-left (xs:Array<SetItem<K>>, i:Int, n:Int) :
+  defn* shift-left (xs:RawArray<SetItem<K>>, i:Int, n:Int) :
     for j in i to (n - 1) do :
       xs[j] = xs[j + 1]    
 
   ;Copy to new array with hole in position i
-  defn* copy-with-hole (xs:Array<SetItem<K>>, i:Int, n:Int) :
-    val xs* = Array<SetItem<K>>(length(xs) * 2)
+  defn* copy-with-hole (xs:RawArray<SetItem<K>>, i:Int, n:Int) :
+    val xs* = RawArray<SetItem<K>>(length(xs) * 2)
     xs*[0 to i] = xs[0 to i]
     xs*[(i + 1) to (n + 1)] = xs[i to n]
     xs*
@@ -1359,7 +1359,7 @@ public defn HashSet<K> (cap0:Int
     do(put, items)
 
   defn create-bucket (slot:Int, x0:SetItem<K>, x1:SetItem<K>) :
-    val bucket = Array<SetItem<K>>(4)
+    val bucket = RawArray<SetItem<K>>(4)
     slots[slot] = bucket
     sizes[slot] = 2
     ;Populate bucket
@@ -1372,7 +1372,7 @@ public defn HashSet<K> (cap0:Int
       bucket[0] = x1
       bucket[1] = x0
 
-  defn add-to-bucket (slot:Int, bucket:Array<SetItem<K>>, i:Int, n:Int, x:SetItem<K>) :
+  defn add-to-bucket (slot:Int, bucket:RawArray<SetItem<K>>, i:Int, n:Int, x:SetItem<K>) :
     ;Case 1 of 2: Bucket has space.
     if n + 1 < length(bucket) :
       shift-right(bucket, i, n)
@@ -1408,7 +1408,7 @@ public defn HashSet<K> (cap0:Int
           increment-size()
           true
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<SetItem<K>>) :
+      (s:RawArray<SetItem<K>>) :
         val n = sizes[slot]
         val i = num-before(s, n, x)
         match(index-of-item(s, i, n, x)) :
@@ -1432,7 +1432,7 @@ public defn HashSet<K> (cap0:Int
       ;Case 2 of 3: Single item bucket
       (s:SetItem<K>) : match?(s,x)
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<SetItem<K>>) :
+      (s:RawArray<SetItem<K>>) :
         val n = sizes[slot]
         val i = num-before(s, n, x)
         index-of-item(s, i, n, x) is Int
@@ -1454,7 +1454,7 @@ public defn HashSet<K> (cap0:Int
           decrement-size()
           true
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<SetItem<K>>) :
+      (s:RawArray<SetItem<K>>) :
         val n = sizes[slot]
         val i = num-before(s, n, x)
         match(index-of-item(s, i, n, x)) :
@@ -1476,7 +1476,7 @@ public defn HashSet<K> (cap0:Int
         match(slots[idx]) :
           (s:Sentinel) : false
           (s:SetItem<K>) : yield(f(s))
-          (s:Array<SetItem<K>>) : for j in 0 to sizes[idx] do : yield(f(s[j]))
+          (s:RawArray<SetItem<K>>) : for j in 0 to sizes[idx] do : yield(f(s[j]))
 
   ;======================
   ;==== Table Object ====
@@ -1544,7 +1544,7 @@ public defn IntSet (cap0:Int) :
     cap = c
     limit = c * 3 / 4
     mask = cap - 1
-    slots = Array<Sentinel|Int|IntArray>(cap, sentinel())
+    slots = RawArray<Sentinel|Int|IntArray>(cap, sentinel())
     sizes = IntArray(cap, 0)
     size = 0
 

--- a/core/collections.stanza
+++ b/core/collections.stanza
@@ -53,6 +53,17 @@ defn bsearch<?T,?S> (less?: (T, S) -> True|False,
       if xs[i + m] < v : loop(i + m + 1, n - m - 1)
       else : loop(i, m)
 
+defn bsearch (less?: (Int, Int) -> True|False, xs:IntArray, n:Int, v:Int) -> Int :
+  ;All items with index less than i are known to be smaller than v.
+  ;All items with index (i + n) or greater are known to be greater or equal to v.
+  let loop (i:Int = 0, n:Int = n) :
+    if n == 0 :
+      i
+    else :
+      val m = n / 2
+      if xs[i + m] < v : loop(i + m + 1, n - m - 1)
+      else : loop(i, m)
+
 ;============================================================
 ;===================== Vectors ==============================
 ;============================================================
@@ -438,7 +449,7 @@ public defn HashTable<K,V> (cap0:Int
     limit = c * 3 / 4
     mask = cap - 1
     slots = Array<Sentinel|TableItem<K,V>|Array<TableItem<K,V>>>(cap, sentinel())
-    sizes = Array<Int>(cap, 0)
+    sizes = IntArray(cap, 0)
     size = 0
 
   defn clear () :
@@ -861,7 +872,7 @@ public defn IntTable<V> (cap0:Int
     limit = c * 3 / 4
     mask = cap - 1
     slots = Array<Sentinel|IntItem<V>|Array<IntItem<V>>>(cap, sentinel())
-    sizes = Array<Int>(cap, 0)
+    sizes = IntArray(cap, 0)
     size = 0
 
   defn clear () :
@@ -1280,7 +1291,7 @@ public defn HashSet<K> (cap0:Int
     limit = c * 3 / 4
     mask = cap - 1
     slots = Array<Sentinel|SetItem<K>|Array<SetItem<K>>>(cap, sentinel())
-    sizes = Array<Int>(cap, 0)
+    sizes = IntArray(cap, 0)
     size = 0
 
   defn clear () :
@@ -1533,8 +1544,8 @@ public defn IntSet (cap0:Int) :
     cap = c
     limit = c * 3 / 4
     mask = cap - 1
-    slots = Array<Sentinel|Int|Array<Int>>(cap, sentinel())
-    sizes = Array<Int>(cap, 0)
+    slots = Array<Sentinel|Int|IntArray>(cap, sentinel())
+    sizes = IntArray(cap, 0)
     size = 0
 
   defn clear () :
@@ -1550,28 +1561,28 @@ public defn IntSet (cap0:Int) :
     h & mask
 
   ;Find number of items whose hash is less than h
-  defn num-before (xs:Array<Int>, n:Int, x:Int) :
+  defn num-before (xs:IntArray, n:Int, x:Int) :
     bsearch(less?, xs, n, x)
 
   ;Look for item with given hash and key starting from i
-  defn* index-of-item (xs:Array<Int>, i:Int, n:Int, y:Int) :
+  defn* index-of-item (xs:IntArray, i:Int, n:Int, y:Int) :
     if i < n :
       val x = xs[i]
       if x == y : i
 
   ;Shift items in xs from i to n right by one element
-  defn* shift-right (xs:Array<Int>, i:Int, n:Int) :
+  defn* shift-right (xs:IntArray, i:Int, n:Int) :
     for j in n to i by -1 do :
       xs[j] = xs[j - 1]
 
   ;Shift items in xs from (i + 1) to n left by one element
-  defn* shift-left (xs:Array<Int>, i:Int, n:Int) :
+  defn* shift-left (xs:IntArray, i:Int, n:Int) :
     for j in i to (n - 1) do :
       xs[j] = xs[j + 1]    
 
   ;Copy to new array with hole in position i
-  defn* copy-with-hole (xs:Array<Int>, i:Int, n:Int) :
-    val xs* = Array<Int>(length(xs) * 2)
+  defn* copy-with-hole (xs:IntArray, i:Int, n:Int) :
+    val xs* = IntArray(length(xs) * 2)
     xs*[0 to i] = xs[0 to i]
     xs*[(i + 1) to (n + 1)] = xs[i to n]
     xs*
@@ -1592,7 +1603,7 @@ public defn IntSet (cap0:Int) :
     do(put, items)
 
   defn create-bucket (slot:Int, x0:Int, x1:Int) :
-    val bucket = Array<Int>(4)
+    val bucket = IntArray(4)
     slots[slot] = bucket
     sizes[slot] = 2
     ;Populate bucket
@@ -1605,7 +1616,7 @@ public defn IntSet (cap0:Int) :
       bucket[0] = x1
       bucket[1] = x0
 
-  defn add-to-bucket (slot:Int, bucket:Array<Int>, i:Int, n:Int, x:Int) :
+  defn add-to-bucket (slot:Int, bucket:IntArray, i:Int, n:Int, x:Int) :
     ;Case 1 of 2: Bucket has space.
     if n + 1 < length(bucket) :
       shift-right(bucket, i, n)
@@ -1641,7 +1652,7 @@ public defn IntSet (cap0:Int) :
           increment-size()
           true
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<Int>) :
+      (s:IntArray) :
         val n = sizes[slot]
         val i = num-before(s, n, x)
         match(index-of-item(s, i, n, x)) :
@@ -1665,7 +1676,7 @@ public defn IntSet (cap0:Int) :
       ;Case 2 of 3: Single item bucket
       (s:Int) : s == x
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<Int>) :
+      (s:IntArray) :
         val n = sizes[slot]
         val i = num-before(s, n, x)
         index-of-item(s, i, n, x) is Int
@@ -1687,7 +1698,7 @@ public defn IntSet (cap0:Int) :
           decrement-size()
           true
       ;Case 3 of 3: Multiple item bucket
-      (s:Array<Int>) :
+      (s:IntArray) :
         val n = sizes[slot]
         val i = num-before(s, n, x)
         match(index-of-item(s, i, n, x)) :
@@ -1709,7 +1720,7 @@ public defn IntSet (cap0:Int) :
         match(slots[idx]) :
           (s:Sentinel) : false
           (s:Int) : yield(s)
-          (s:Array<Int>) : for j in 0 to sizes[idx] do : yield(s[j])
+          (s:IntArray) : for j in 0 to sizes[idx] do : yield(s[j])
 
   ;======================
   ;==== Table Object ====

--- a/core/core.stanza
+++ b/core/core.stanza
@@ -7588,78 +7588,59 @@ public deftype Array<T> <: IndexedCollection<T> & Unique
 ;                     Implementation
 ;                     ==============
 
-lostanza deftype RawArray<T> <: Array<T> :
+public lostanza deftype RawArray<T> <: Array<T> :
    length: long
    var items: ref<?> ...
 
-lostanza defn RawArray<T> (n:ref<Int>, x:ref<?>) -> ref<RawArray<T>> :
-   val l = n.value
-   val a = new RawArray<T>{l}
-   for (var i:long = 0, i < l, i = i + 1) :
-      a.items[i] = x
-   return a
+public lostanza defn RawArray<T> (n:ref<Int>, x:ref<?>) -> ref<RawArray<T>> :
+  ensure-non-negative-length(n)
+  val l = n.value
+  val a = new RawArray<T>{l}
+  for (var i:long = 0, i < l, i = i + 1) :
+    a.items[i] = x
+  return a
 
-lostanza defmethod get<?T> (a:ref<RawArray<?T>>, i:ref<Int>) -> ref<T> :
+public defn RawArray<T> (n:Int) -> RawArray<T> :
+  ensure-non-negative-length(n)
+  RawArray<T>(n, sentinel)
+
+lostanza defn do-get<?T> (a:ref<RawArray<?T>>, i:ref<Int>) -> ref<T> :
   return a.items[i.value]
 
+defmethod get<?T> (a:RawArray<?T>, i:Int) -> T :
+  #if-defined(OPTIMIZED) :
+    do-get(a, i)
+  #else :
+    ensure-index-in-bounds(a, i)
+    match(do-get(a,i)) :
+      (v:Sentinel) : fatal("Index (%_) is uninitialized." % [i])
+      (v) : v
+
 lostanza defmethod set<?T> (a:ref<RawArray<?T>>, i:ref<Int>, v:ref<?T>) -> ref<False> :
+  ensure-index-in-bounds(a, i)
   a.items[i.value] = v
   return false
 
 lostanza defmethod set-all<?T> (xs:ref<RawArray<?T>>, r:ref<Range>, v:ref<?T>) -> ref<False> :
-   val range = range-bound(xs, r) as ref<Tuple<Int>>
-   val b = range.items[0].value
-   val e = range.items[1].value
-   for (var i:long = b, i < e, i = i + 1) :
-      xs.items[i] = v
-   return false
+  ensure-index-range(xs, r)
+  val range = range-bound(xs, r) as ref<Tuple<Int>>
+  val b = range.items[0].value
+  val e = range.items[1].value
+  for (var i:long = b, i < e, i = i + 1) :
+    xs.items[i] = v
+  return false
 
 lostanza defmethod length (a:ref<RawArray>) -> ref<Int> :
-   return new Int{a.length as int}
+  return new Int{a.length as int}
 
 defmethod print (o:OutputStream, a:RawArray) -> False :
-   print(o, "[%@]" % [a])
+  print(o, "[%@]" % [a])
 
-;                     Wrapping
-;                     ========
+public defn Array<T> (n:Int) -> RawArray<T> :
+  RawArray<T>(n, sentinel)
 
-#if-defined(OPTIMIZE) :
-
-   public defn Array<T> (n:Int) -> RawArray<T> :
-      RawArray<T>(n, sentinel)
-
-   public defn Array<T> (n:Int, x:T) -> RawArray<T> :
-      RawArray<T>(n, x)
-
-#else :
-
-   deftype WrappedArray<T> <: Array<T>
-
-   public defn Array<T> (n:Int) -> Array<T> :
-      ensure-non-negative("length", n)
-      Array<T>(RawArray<T>(n, sentinel))
-
-   public defn Array<T> (n:Int, x:T) -> Array<T> :
-      ensure-non-negative("length", n)
-      Array<T>(RawArray<T>(n, x))
-
-   defn Array<T> (a:RawArray) -> Array<T> :
-      new WrappedArray<T> :
-         defmethod get (this, i:Int) :
-            ensure-index-in-bounds(a, i)
-            match(a[i]) :
-               (v:Sentinel) : fatal("Index (%_) is uninitialized." % [i])
-               (v) : v
-         defmethod set (this, i:Int, v:T) :
-            ensure-index-in-bounds(a, i)
-            a[i] = v
-         defmethod set-all (this, r:Range, v:T) :
-            ensure-index-range(a, r)
-            set-all(a, r, v)
-         defmethod length (this) :
-            length(a)
-         defmethod print (o:OutputStream, this) :
-            print(o, a)
+public defn Array<T> (n:Int, x:T) -> RawArray<T> :
+  RawArray<T>(n, x)
 
 public defn map<R,?T> (xs:Array<?T>, f: T -> R) -> Array<R> :
   map<R>(f, xs)


### PR DESCRIPTION
export RawArray and redo definition of Array to be more efficient in both optimized and unoptimized mode.  replace uses of Array<Int> with IntArray in collections and compiler.  replace uses of Array with RawArray in compiler.